### PR TITLE
Selu addition

### DIFF
--- a/learnergy/models/deep/dbn.py
+++ b/learnergy/models/deep/dbn.py
@@ -11,7 +11,7 @@ from learnergy.core import Dataset, Model
 from learnergy.models.bernoulli import RBM, DropoutRBM, EDropoutRBM
 from learnergy.models.extra import SigmoidRBM
 from learnergy.models.gaussian import (GaussianRBM, GaussianReluRBM,
-                                       VarianceGaussianRBM)
+                                       GaussianSeluRBM, VarianceGaussianRBM)
 
 logger = l.get_logger(__name__)
 
@@ -21,6 +21,7 @@ MODELS = {
     'e_dropout': EDropoutRBM,
     'gaussian': GaussianRBM,
     'gaussian_relu': GaussianReluRBM,
+    'gaussian_selu': GaussianSeluRBM,
     'sigmoid': SigmoidRBM,
     'variance_gaussian': VarianceGaussianRBM
 }

--- a/learnergy/models/gaussian/__init__.py
+++ b/learnergy/models/gaussian/__init__.py
@@ -4,4 +4,5 @@
 from learnergy.models.gaussian.gaussian_conv_rbm import GaussianConvRBM
 from learnergy.models.gaussian.gaussian_rbm import (GaussianRBM,
                                                     GaussianReluRBM,
+                                                    GaussianSeluRBM,
                                                     VarianceGaussianRBM)

--- a/tests/learnergy/models/gaussian/test_gaussian_rbm.py
+++ b/tests/learnergy/models/gaussian/test_gaussian_rbm.py
@@ -1,6 +1,33 @@
 import torch
 
 from learnergy.models.gaussian import gaussian_rbm
+ 
+def test_gaussian_rbm_normalize_setter():
+    new_gaussian_rbm = gaussian_rbm.GaussianRBM()
+
+    new_gaussian_rbm.normalize = False
+    
+    assert new_gaussian_rbm.normalize == False
+
+
+def test_gaussian_rbm_normalize():
+    new_gaussian_rbm = gaussian_rbm.GaussianRBM()
+
+    assert new_gaussian_rbm.normalize == True
+
+def test_gaussian_rbm_input_normalize_setter():
+    new_gaussian_rbm = gaussian_rbm.GaussianRBM()
+
+    new_gaussian_rbm.input_normalize = False 
+
+    assert new_gaussian_rbm.input_normalize == False 
+
+
+def test_gaussian_rbm_input_normalize():
+    new_gaussian_rbm = gaussian_rbm.GaussianRBM()
+
+    assert new_gaussian_rbm.input_normalize == True
+
 
 
 def test_gaussian_rbm_visible_sampling():
@@ -30,6 +57,21 @@ def test_gaussian_relu_rbm_hidden_sampling():
     assert states.size(1) == 128
 
     probs, states = new_gaussian_relu_rbm.hidden_sampling(v, scale=False)
+
+    assert probs.size(1) == 128
+    assert states.size(1) == 128
+
+def test_gaussian_selu_rbm_hidden_sampling():
+    new_gaussian_selu_rbm = gaussian_rbm.GaussianSeluRBM()
+
+    v = torch.ones(1, 128)
+
+    probs, states = new_gaussian_selu_rbm.hidden_sampling(v, scale=True)
+
+    assert probs.size(1) == 128
+    assert states.size(1) == 128
+
+    probs, states = new_gaussian_selu_rbm.hidden_sampling(v, scale=False)
 
     assert probs.size(1) == 128
     assert states.size(1) == 128


### PR DESCRIPTION
Adding Gaussian RBM with hidden layer SELU activation. In addition to the SELU addition, added boolean flags to indicate whether or not to batch normalize and normalize the input within parent GaussianRBM class.

The batch normalization is removed for SELU RBM, as it self-normalizes. Also, I use a scaling functionality outside of learnergy for the input, so it would be useful to have the normalization internal to learnergy as an option.

By default input and batch normalization is turned on, as to not cause issues for other users.