### PR TITLE
Add Gaussian and variance Gaussian RTRBMs and RTDBN temporal models

### DIFF
--- a/learnergy/models/temporal/__init__.py
+++ b/learnergy/models/temporal/__init__.py
@@ -1,3 +1,6 @@
 """A package containing temporal models for all common learnergy modules.
 """
 from learnergy.models.temporal.rtrbm import RTRBM
+from learnergy.models.temporal.rt_gaussian_rbm import RTGaussianRBM
+from learnergy.models.temporal.rt_variance_gaussian_rbm import RTVarianceGaussianRBM
+from learnergy.models.temporal.rtdbn import RTDBN, IICClusteringHead

--- a/learnergy/models/temporal/__init__.py
+++ b/learnergy/models/temporal/__init__.py
@@ -3,4 +3,4 @@
 from learnergy.models.temporal.rtrbm import RTRBM
 from learnergy.models.temporal.rt_gaussian_rbm import RTGaussianRBM
 from learnergy.models.temporal.rt_variance_gaussian_rbm import RTVarianceGaussianRBM
-from learnergy.models.temporal.rtdbn import RTDBN, IICClusteringHead
+from learnergy.models.temporal.rtdbn import RTDBN

--- a/learnergy/models/temporal/rt_gaussian_rbm.py
+++ b/learnergy/models/temporal/rt_gaussian_rbm.py
@@ -1,0 +1,412 @@
+"""Gaussian-Bernoulli Recurrent Temporal Restricted Boltzmann Machine.
+
+Extends RTRBM (Bernoulli visible) with Gaussian visible units, making it
+suitable for continuous-valued data like biomechanical time series.
+
+The recurrent mechanism (W_prime, h0, hidden_sampling, fit_subseries,
+fit, forward, reconstruct, sample) is inherited unchanged from RTRBM --
+recurrence only touches the hidden layer, not the visible one.
+
+Only four things change vs. Bernoulli RTRBM:
+  1. energy()           -- quadratic visible term (v - a)^2 instead of -v*a
+  2. visible_sampling() -- linear activations, not Bernoulli samples
+  3. normalize/input_normalize -- per-batch normalization flags
+  4. fit_subseries()    -- applies per-batch normalization before training,
+                          mirroring GaussianRBM.fit()'s normalize step
+"""
+from typing import Tuple
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from learnergy.utils import logging
+from learnergy.models.temporal.rtrbm import RTRBM
+
+logger = logging.get_logger(__name__)
+
+
+class RTGaussianRBM(RTRBM):
+    """Gaussian-Bernoulli Recurrent Temporal RBM.
+
+    Extends RTRBM by replacing Bernoulli visible units with Gaussian
+    visible units (variance fixed to 1, same as GaussianRBM in
+    learnergy's gaussian_rbm.py). All recurrent machinery inherited
+    from RTRBM unchanged.
+
+    Use this instead of RTRBM for continuous-valued input data
+    (e.g. biomechanical joint angles, velocities, muscle activations).
+    """
+
+    def __init__(
+        self,
+        n_visible: int = 128,
+        n_hidden: int = 128,
+        steps: int = 1,
+        learning_rate: float = 0.1,
+        momentum: float = 0.0,
+        decay: float = 0.0,
+        temperature: float = 1.0,
+        use_gpu: bool = False,
+        normalize: bool = True,
+        input_normalize: bool = True,
+    ) -> None:
+        """Initialization method.
+
+        Args mirror GaussianRBM.__init__ (gaussian_rbm.py) with the
+        addition of all RTRBM recurrent parameters (W_prime, h0) added
+        by the parent RTRBM.__init__.
+
+        Args:
+            n_visible: Amount of visible units.
+            n_hidden: Amount of hidden units.
+            steps: Number of Gibbs' sampling steps.
+            learning_rate: Learning rate.
+            momentum: Momentum parameter.
+            decay: Weight decay used for penalization.
+            temperature: Temperature factor.
+            use_gpu: Whether GPU should be used or not.
+            normalize: Whether or not to use batch normalization during
+                fit(). Mirrors GaussianRBM's normalize parameter.
+            input_normalize: Whether or not to normalize inputs during
+                forward(). Mirrors GaussianRBM's input_normalize parameter.
+        """
+        # Set normalize flags BEFORE calling super().__init__() --
+        # matches the order GaussianRBM.__init__ uses in gaussian_rbm.py.
+        self._normalize = normalize
+        self._input_normalize = input_normalize
+
+        logger.info("Overriding class: RTRBM -> RTGaussianRBM.")
+
+        super(RTGaussianRBM, self).__init__(
+            n_visible,
+            n_hidden,
+            steps,
+            learning_rate,
+            momentum,
+            decay,
+            temperature,
+            use_gpu,
+        )
+
+        logger.info("Class overrided.")
+
+    @property
+    def normalize(self) -> bool:
+        """Whether or not to use batch normalization during fit()."""
+        return self._normalize
+
+    @normalize.setter
+    def normalize(self, normalize: bool) -> None:
+        self._normalize = normalize
+
+    @property
+    def input_normalize(self) -> bool:
+        """Whether or not to normalize inputs during forward()."""
+        return self._input_normalize
+
+    @input_normalize.setter
+    def input_normalize(self, input_normalize: bool) -> None:
+        self._input_normalize = input_normalize
+
+    def energy(self, samples: torch.Tensor, h_prev: torch.Tensor) -> torch.Tensor:
+        """Calculates the system's energy for Gaussian visible units.
+
+        Overrides RTRBM.energy() to use the Gaussian visible energy term:
+            E = 0.5 * sum((v - a)^2) - sum(softplus(W^T v + W'h + b))
+
+        The quadratic visible term 0.5*(v-a)^2 replaces the linear -v*a
+        term used in the Bernoulli case, matching GaussianRBM.energy()
+        in gaussian_rbm.py -- the only change for Gaussian visibles.
+        The recurrent bias term (W_prime @ h_prev + b) is inherited from
+        RTRBM.energy().
+
+        Args:
+            samples: Visible samples, shape (batch, n_visible).
+            h_prev: Previous hidden probabilities, shape (batch, n_hidden).
+
+        Returns:
+            System energy per sample, shape (batch,).
+        """
+        recurrent_bias = F.linear(h_prev, self.W_prime, self.b)
+        activations = F.linear(samples, self.W.t()) + recurrent_bias
+
+        s = nn.Softplus()
+        h = torch.sum(s(activations), dim=1)
+
+        # Gaussian visible term -- replaces Bernoulli's -v*a
+        # Mirrors GaussianRBM.energy() in gaussian_rbm.py exactly
+        v = 0.5 * torch.sum((samples - self.a) ** 2, dim=1)
+
+        energy = v - h
+
+        return energy
+
+    def gibbs_sampling(
+        self, v: torch.Tensor, h_prev: torch.Tensor
+    ):
+        """Overrides RTRBM.gibbs_sampling for Gaussian visible units.
+
+        KEY FIX: For Gaussian visible units, uses the mean field value
+        (linear activation) directly during the Gibbs loop instead of
+        sampling noisy visible states. This is standard practice for
+        Gaussian-Bernoulli RBMs -- see:
+
+        Hinton & Salakhutdinov (2006): "rather than sampling from the
+        distribution, the visible units can be set equal to their means"
+
+        Using sampled values introduces noise that causes activation
+        explosion and NaN during CD-k with continuous visible units,
+        especially when combined with per-batch normalization.
+        """
+        pos_hidden_probs, pos_hidden_states = self.hidden_sampling(v, h_prev)
+        neg_hidden_states = pos_hidden_states
+
+        for _ in range(self.steps):
+            # Use visible_probs (mean field) not visible_states (samples)
+            # for Gaussian visible units -- prevents activation explosion
+            visible_probs, visible_states = self.visible_sampling(
+                neg_hidden_states, True
+            )
+
+            neg_hidden_probs, neg_hidden_states = self.hidden_sampling(
+                visible_probs, h_prev, True
+            )
+
+        return (
+            pos_hidden_probs,
+            pos_hidden_states,
+            neg_hidden_probs,
+            neg_hidden_states,
+            visible_probs,
+        )
+
+    def hidden_sampling(
+        self, v: torch.Tensor, h_prev: torch.Tensor, scale: bool = False
+    ):
+        """Overrides RTRBM.hidden_sampling to clamp probabilities and
+        guard against NaN values in h_prev.
+
+        After per-batch normalization, large activations during Gibbs
+        sampling can produce NaN hidden states that propagate through
+        the recurrent chain. Clamping h_prev and probs prevents this.
+        """
+        # Guard against NaN in h_prev -- can occur during Gibbs sampling
+        # after normalization makes activations large
+        h_prev = torch.nan_to_num(h_prev, nan=0.0)
+        h_prev = torch.clamp(h_prev, 0.0, 1.0)
+
+        recurrent_bias = F.linear(h_prev, self.W_prime, self.b)
+        activations = F.linear(v, self.W.t()) + recurrent_bias
+
+        if scale:
+            probs = torch.sigmoid(torch.div(activations, self.T))
+        else:
+            probs = torch.sigmoid(activations)
+
+        # Clamp to avoid numerical issues with torch.bernoulli
+        probs = torch.clamp(probs, 1e-6, 1 - 1e-6)
+        states = torch.bernoulli(probs)
+
+        return probs, states
+
+    def fit_subseries(self, sequence: torch.Tensor) -> torch.Tensor:
+        """Overrides RTRBM.fit_subseries to apply per-batch normalization
+        before training, mirroring GaussianRBM.fit()'s normalize step
+        (gaussian_rbm.py lines 184-188).
+
+        Per-batch normalization (zero mean, unit std per feature) is
+        essential for Gaussian visible units -- without it, the unbounded
+        linear activations cause the model to collapse to outputting a
+        constant value (the data mean) immediately, ignoring the data
+        structure entirely. This is a known issue with Gaussian RBMs
+        documented in Cho, Ilin & Raiko (2011).
+
+        The normalization is applied per-subseries batch, not globally --
+        same as GaussianRBM.fit() does per-batch. This is separate from
+        the external MinMaxScaler preprocessing, which scales across the
+        full dataset.
+
+        Args:
+            sequence: One subseries, shape (batch, seq_len, n_visible).
+
+        Returns:
+            MSE for this subseries.
+        """
+        if self.normalize:
+            batch_size, seq_len, n_visible = sequence.shape
+            flat = sequence.reshape(-1, n_visible)
+            flat = (
+                (flat - torch.mean(flat, 0, True))
+                / (torch.std(flat, 0, True) + 1e-6)
+            ).detach()
+            sequence = flat.reshape(batch_size, seq_len, n_visible)
+
+        # Run the full subseries training loop with gradient clipping.
+        # We can't call super().fit_subseries() and add clipping after
+        # since the optimizer.step() is inside that method. Instead we
+        # replicate the loop here with clipping added -- matches the
+        # same pattern but adds stability for Gaussian training.
+        batch_size, seq_len, n_visible = sequence.shape
+        h_prev = self.h0.unsqueeze(0).expand(batch_size, -1)
+        self.optimizer.zero_grad()
+
+        total_cost = torch.tensor(0.0)
+        total_mse = torch.tensor(0.0)
+
+        for t in range(seq_len):
+            v_t = sequence[:, t, :]
+            _, _, _, _, visible_states = self.gibbs_sampling(v_t, h_prev)
+            visible_states = visible_states.detach()
+
+            cost_t = torch.mean(self.energy(v_t, h_prev)) - torch.mean(
+                self.energy(visible_states, h_prev)
+            )
+            total_cost = total_cost + cost_t
+
+            batch_mse = torch.div(
+                torch.sum(torch.pow(v_t - visible_states, 2)), batch_size
+            ).detach()
+            total_mse = total_mse + batch_mse
+
+            h_prev, _ = self.hidden_sampling(v_t, h_prev)
+            # Guard against NaN propagation through the recurrent chain
+            h_prev = torch.nan_to_num(h_prev, nan=0.5)
+            h_prev = torch.clamp(h_prev, 0.0, 1.0)
+
+        total_cost.backward()
+
+        # Gradient clipping -- prevents weight explosion when training
+        # with per-batch normalized data, which can produce large gradients.
+        torch.nn.utils.clip_grad_norm_(self.parameters(), max_norm=1.0)
+
+        self.optimizer.step()
+
+        return total_mse
+
+    def visible_sampling(
+        self, h: torch.Tensor, scale: bool = False
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Performs visible layer sampling for Gaussian units, P(v|h).
+
+        Overrides RBM.visible_sampling (inherited via RTRBM). For
+        Gaussian visible units, the mean of P(v|h) is simply the linear
+        activation W*h + a -- no sigmoid, no Bernoulli sampling. This
+        gives continuous-valued outputs instead of binary ones, which is
+        exactly what we need for biomechanical data.
+
+        Mirrors GaussianRBM.visible_sampling() in gaussian_rbm.py exactly.
+
+        Args:
+            h: Hidden layer tensor, shape (batch, n_hidden).
+            scale: Whether to divide by temperature T.
+
+        Returns:
+            (probs, states): both are the linear activation for Gaussian
+            units (probs = sigmoid of states, states = linear activation).
+        """
+        activations = F.linear(h, self.W, self.a)
+
+        if scale:
+            states = torch.div(activations, self.T)
+        else:
+            states = activations
+
+        probs = torch.sigmoid(states)
+
+        return probs, states
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Overrides RTRBM.forward() to apply input normalization.
+
+        Mirrors GaussianRBM.forward() (gaussian_rbm.py lines 285-288),
+        adapted for temporal (batch, seq_len, n_visible) input shape.
+        Without this, forward() sees un-normalized data but the model
+        was trained on normalized data -- causing poor hidden embeddings.
+        """
+        if self.input_normalize:
+            batch_size, seq_len, n_visible = x.shape
+            flat = x.reshape(-1, n_visible)
+            flat = (
+                (flat - torch.mean(flat, 0, True))
+                / (torch.std(flat, 0, True) + 1e-6)
+            ).detach()
+            x = flat.reshape(batch_size, seq_len, n_visible)
+
+        batch_size, seq_len, n_visible = x.shape
+        h_prev = self.h0.unsqueeze(0).expand(batch_size, -1)
+        all_probs = []
+        for t in range(seq_len):
+            v_t = x[:, t, :]
+            probs, _ = self.hidden_sampling(v_t, h_prev)
+            all_probs.append(probs.unsqueeze(1))
+            h_prev = probs
+        return torch.cat(all_probs, dim=1)
+
+    def reconstruct(
+        self, dataset: torch.utils.data.Dataset
+    ) -> Tuple[float, torch.Tensor]:
+        """Overrides RTRBM.reconstruct() to normalize during reconstruction.
+
+        Mirrors GaussianRBM.reconstruct() (gaussian_rbm.py lines 249-254).
+        The model was trained on per-batch normalized data -- without
+        applying the same normalization during reconstruction, the model
+        sees a completely different data distribution and reconstructions
+        are meaningless.
+        """
+        from torch.utils.data import DataLoader
+        from tqdm import tqdm
+
+        logger.info("Reconstructing new samples ...")
+
+        mse = torch.tensor(0.0)
+        batch_size = len(dataset)
+        batches = DataLoader(
+            dataset, batch_size=batch_size, shuffle=False, num_workers=0
+        )
+        visible_probs_all = []
+
+        for samples, _ in tqdm(batches):
+            if self.device == "cuda":
+                samples = samples.cuda()
+
+            if self.normalize:
+                b, s, n = samples.shape
+                flat = samples.reshape(-1, n)
+                flat = (
+                    (flat - torch.mean(flat, 0, True))
+                    / (torch.std(flat, 0, True) + 1e-6)
+                ).detach()
+                samples = flat.reshape(b, s, n)
+
+            batch_size_actual = samples.size(0)
+            seq_len = samples.size(1)
+            h_prev = self.h0.unsqueeze(0).expand(batch_size_actual, -1)
+            recon_probs = []
+            recon_states = []
+
+            for t in range(seq_len):
+                v_t = samples[:, t, :]
+                pos_hidden_probs, pos_hidden_states = self.hidden_sampling(
+                    v_t, h_prev
+                )
+                visible_prob, visible_state = self.visible_sampling(
+                    pos_hidden_states
+                )
+                recon_probs.append(visible_prob.unsqueeze(1))
+                recon_states.append(visible_state.unsqueeze(1))
+                h_prev = pos_hidden_probs
+
+            recon_probs_seq = torch.cat(recon_probs, dim=1)
+            recon_states_seq = torch.cat(recon_states, dim=1)
+
+            batch_mse = torch.div(
+                torch.sum(torch.pow(samples - recon_states_seq, 2)),
+                batch_size_actual
+            ).detach()
+            mse += batch_mse
+            visible_probs_all.append(recon_probs_seq)
+
+        mse /= len(batches)
+        logger.info("MSE: %f", mse)
+        return mse, torch.cat(visible_probs_all, dim=0)

--- a/learnergy/models/temporal/rt_gaussian_rbm.py
+++ b/learnergy/models/temporal/rt_gaussian_rbm.py
@@ -3,10 +3,6 @@
 Extends RTRBM (Bernoulli visible) with Gaussian visible units, making it
 suitable for continuous-valued data like biomechanical time series.
 
-The recurrent mechanism (W_prime, h0, hidden_sampling, fit_subseries,
-fit, forward, reconstruct, sample) is inherited unchanged from RTRBM --
-recurrence only touches the hidden layer, not the visible one.
-
 Only four things change vs. Bernoulli RTRBM:
   1. energy()           -- quadratic visible term (v - a)^2 instead of -v*a
   2. visible_sampling() -- linear activations, not Bernoulli samples
@@ -27,17 +23,6 @@ logger = logging.get_logger(__name__)
 
 
 class RTGaussianRBM(RTRBM):
-    """Gaussian-Bernoulli Recurrent Temporal RBM.
-
-    Extends RTRBM by replacing Bernoulli visible units with Gaussian
-    visible units (variance fixed to 1, same as GaussianRBM in
-    learnergy's gaussian_rbm.py). All recurrent machinery inherited
-    from RTRBM unchanged.
-
-    Use this instead of RTRBM for continuous-valued input data
-    (e.g. biomechanical joint angles, velocities, muscle activations).
-    """
-
     def __init__(
         self,
         n_visible: int = 128,
@@ -51,26 +36,7 @@ class RTGaussianRBM(RTRBM):
         normalize: bool = True,
         input_normalize: bool = True,
     ) -> None:
-        """Initialization method.
 
-        Args mirror GaussianRBM.__init__ (gaussian_rbm.py) with the
-        addition of all RTRBM recurrent parameters (W_prime, h0) added
-        by the parent RTRBM.__init__.
-
-        Args:
-            n_visible: Amount of visible units.
-            n_hidden: Amount of hidden units.
-            steps: Number of Gibbs' sampling steps.
-            learning_rate: Learning rate.
-            momentum: Momentum parameter.
-            decay: Weight decay used for penalization.
-            temperature: Temperature factor.
-            use_gpu: Whether GPU should be used or not.
-            normalize: Whether or not to use batch normalization during
-                fit(). Mirrors GaussianRBM's normalize parameter.
-            input_normalize: Whether or not to normalize inputs during
-                forward(). Mirrors GaussianRBM's input_normalize parameter.
-        """
         # Set normalize flags BEFORE calling super().__init__() --
         # matches the order GaussianRBM.__init__ uses in gaussian_rbm.py.
         self._normalize = normalize
@@ -114,19 +80,6 @@ class RTGaussianRBM(RTRBM):
 
         Overrides RTRBM.energy() to use the Gaussian visible energy term:
             E = 0.5 * sum((v - a)^2) - sum(softplus(W^T v + W'h + b))
-
-        The quadratic visible term 0.5*(v-a)^2 replaces the linear -v*a
-        term used in the Bernoulli case, matching GaussianRBM.energy()
-        in gaussian_rbm.py -- the only change for Gaussian visibles.
-        The recurrent bias term (W_prime @ h_prev + b) is inherited from
-        RTRBM.energy().
-
-        Args:
-            samples: Visible samples, shape (batch, n_visible).
-            h_prev: Previous hidden probabilities, shape (batch, n_hidden).
-
-        Returns:
-            System energy per sample, shape (batch,).
         """
         recurrent_bias = F.linear(h_prev, self.W_prime, self.b)
         activations = F.linear(samples, self.W.t()) + recurrent_bias
@@ -146,18 +99,6 @@ class RTGaussianRBM(RTRBM):
         self, v: torch.Tensor, h_prev: torch.Tensor
     ):
         """Overrides RTRBM.gibbs_sampling for Gaussian visible units.
-
-        KEY FIX: For Gaussian visible units, uses the mean field value
-        (linear activation) directly during the Gibbs loop instead of
-        sampling noisy visible states. This is standard practice for
-        Gaussian-Bernoulli RBMs -- see:
-
-        Hinton & Salakhutdinov (2006): "rather than sampling from the
-        distribution, the visible units can be set equal to their means"
-
-        Using sampled values introduces noise that causes activation
-        explosion and NaN during CD-k with continuous visible units,
-        especially when combined with per-batch normalization.
         """
         pos_hidden_probs, pos_hidden_states = self.hidden_sampling(v, h_prev)
         neg_hidden_states = pos_hidden_states
@@ -184,13 +125,6 @@ class RTGaussianRBM(RTRBM):
     def hidden_sampling(
         self, v: torch.Tensor, h_prev: torch.Tensor, scale: bool = False
     ):
-        """Overrides RTRBM.hidden_sampling to clamp probabilities and
-        guard against NaN values in h_prev.
-
-        After per-batch normalization, large activations during Gibbs
-        sampling can produce NaN hidden states that propagate through
-        the recurrent chain. Clamping h_prev and probs prevents this.
-        """
         # Guard against NaN in h_prev -- can occur during Gibbs sampling
         # after normalization makes activations large
         h_prev = torch.nan_to_num(h_prev, nan=0.0)
@@ -211,28 +145,7 @@ class RTGaussianRBM(RTRBM):
         return probs, states
 
     def fit_subseries(self, sequence: torch.Tensor) -> torch.Tensor:
-        """Overrides RTRBM.fit_subseries to apply per-batch normalization
-        before training, mirroring GaussianRBM.fit()'s normalize step
-        (gaussian_rbm.py lines 184-188).
 
-        Per-batch normalization (zero mean, unit std per feature) is
-        essential for Gaussian visible units -- without it, the unbounded
-        linear activations cause the model to collapse to outputting a
-        constant value (the data mean) immediately, ignoring the data
-        structure entirely. This is a known issue with Gaussian RBMs
-        documented in Cho, Ilin & Raiko (2011).
-
-        The normalization is applied per-subseries batch, not globally --
-        same as GaussianRBM.fit() does per-batch. This is separate from
-        the external MinMaxScaler preprocessing, which scales across the
-        full dataset.
-
-        Args:
-            sequence: One subseries, shape (batch, seq_len, n_visible).
-
-        Returns:
-            MSE for this subseries.
-        """
         if self.normalize:
             batch_size, seq_len, n_visible = sequence.shape
             flat = sequence.reshape(-1, n_visible)
@@ -294,16 +207,6 @@ class RTGaussianRBM(RTRBM):
         activation W*h + a -- no sigmoid, no Bernoulli sampling. This
         gives continuous-valued outputs instead of binary ones, which is
         exactly what we need for biomechanical data.
-
-        Mirrors GaussianRBM.visible_sampling() in gaussian_rbm.py exactly.
-
-        Args:
-            h: Hidden layer tensor, shape (batch, n_hidden).
-            scale: Whether to divide by temperature T.
-
-        Returns:
-            (probs, states): both are the linear activation for Gaussian
-            units (probs = sigmoid of states, states = linear activation).
         """
         activations = F.linear(h, self.W, self.a)
 
@@ -318,11 +221,6 @@ class RTGaussianRBM(RTRBM):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Overrides RTRBM.forward() to apply input normalization.
-
-        Mirrors GaussianRBM.forward() (gaussian_rbm.py lines 285-288),
-        adapted for temporal (batch, seq_len, n_visible) input shape.
-        Without this, forward() sees un-normalized data but the model
-        was trained on normalized data -- causing poor hidden embeddings.
         """
         if self.input_normalize:
             batch_size, seq_len, n_visible = x.shape
@@ -347,12 +245,6 @@ class RTGaussianRBM(RTRBM):
         self, dataset: torch.utils.data.Dataset
     ) -> Tuple[float, torch.Tensor]:
         """Overrides RTRBM.reconstruct() to normalize during reconstruction.
-
-        Mirrors GaussianRBM.reconstruct() (gaussian_rbm.py lines 249-254).
-        The model was trained on per-batch normalized data -- without
-        applying the same normalization during reconstruction, the model
-        sees a completely different data distribution and reconstructions
-        are meaningless.
         """
         from torch.utils.data import DataLoader
         from tqdm import tqdm

--- a/learnergy/models/temporal/rt_gaussian_rbm.py
+++ b/learnergy/models/temporal/rt_gaussian_rbm.py
@@ -37,8 +37,6 @@ class RTGaussianRBM(RTRBM):
         input_normalize: bool = True,
     ) -> None:
 
-        # Set normalize flags BEFORE calling super().__init__() --
-        # matches the order GaussianRBM.__init__ uses in gaussian_rbm.py.
         self._normalize = normalize
         self._input_normalize = input_normalize
 
@@ -87,8 +85,6 @@ class RTGaussianRBM(RTRBM):
         s = nn.Softplus()
         h = torch.sum(s(activations), dim=1)
 
-        # Gaussian visible term -- replaces Bernoulli's -v*a
-        # Mirrors GaussianRBM.energy() in gaussian_rbm.py exactly
         v = 0.5 * torch.sum((samples - self.a) ** 2, dim=1)
 
         energy = v - h
@@ -156,10 +152,6 @@ class RTGaussianRBM(RTRBM):
             sequence = flat.reshape(batch_size, seq_len, n_visible)
 
         # Run the full subseries training loop with gradient clipping.
-        # We can't call super().fit_subseries() and add clipping after
-        # since the optimizer.step() is inside that method. Instead we
-        # replicate the loop here with clipping added -- matches the
-        # same pattern but adds stability for Gaussian training.
         batch_size, seq_len, n_visible = sequence.shape
         h_prev = self.h0.unsqueeze(0).expand(batch_size, -1)
         self.optimizer.zero_grad()
@@ -201,12 +193,6 @@ class RTGaussianRBM(RTRBM):
         self, h: torch.Tensor, scale: bool = False
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         """Performs visible layer sampling for Gaussian units, P(v|h).
-
-        Overrides RBM.visible_sampling (inherited via RTRBM). For
-        Gaussian visible units, the mean of P(v|h) is simply the linear
-        activation W*h + a -- no sigmoid, no Bernoulli sampling. This
-        gives continuous-valued outputs instead of binary ones, which is
-        exactly what we need for biomechanical data.
         """
         activations = F.linear(h, self.W, self.a)
 

--- a/learnergy/models/temporal/rt_variance_gaussian_rbm.py
+++ b/learnergy/models/temporal/rt_variance_gaussian_rbm.py
@@ -1,0 +1,391 @@
+"""Recurrent Temporal Restricted Boltzmann Machine with Learned Variance.
+
+Extends RTRBM with per-feature learned variance (sigma), following
+learnergy's VarianceGaussianRBM (gaussian_rbm.py) exactly. No per-batch
+normalization required -- the model learns the variance of each feature
+directly from data, making it suitable for biomechanical time series where
+different features have genuinely different scales.
+
+This directly addresses the limitation observed with RTGaussianRBM where
+low-variance features (e.g. features 1 and 3 in the reach data) were
+reconstructed as flat lines because per-batch normalization assumed unit
+variance for all features.
+"""
+from typing import Tuple
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+import learnergy.utils.constants as c
+from learnergy.utils import logging
+from learnergy.models.temporal.rtrbm import RTRBM
+
+logger = logging.get_logger(__name__)
+
+
+class RTVarianceGaussianRBM(RTRBM):
+    """Recurrent Temporal RBM with learned per-feature variance.
+
+    Extends RTRBM by adding a learnable sigma parameter (one per visible
+    feature), following VarianceGaussianRBM in learnergy's gaussian_rbm.py
+    exactly. No per-batch normalization needed -- sigma learns the scale
+    of each feature automatically.
+
+    Key differences from RTGaussianRBM:
+    - No normalize/input_normalize flags -- sigma replaces normalization
+    - hidden_sampling divides v by sigma^2 (per Cho et al. 2011 eq. 2)
+    - visible_sampling samples from N(W*h + a, sigma^2) using torch.normal
+    - energy uses quadratic term (v-a)^2 / (2*sigma^2) scaled by learned variance
+    - visible_sampling returns (states, activations) -- REVERSED vs GaussianRBM,
+      matching VarianceGaussianRBM's convention exactly
+
+    Training note (from Cho et al. 2011, Fig 1b): learning diverges if
+    sigma is updated from epoch 1 with a large learning rate. We provide
+    a `train_sigma` flag so sigma can be frozen initially (warmup period)
+    and then enabled once W/a/b have stabilized. Recommended:
+        - Warmup: train_sigma=False for ~10-20 epochs
+        - Then: train_sigma=True for remaining epochs
+    """
+
+    def __init__(
+        self,
+        n_visible: int = 128,
+        n_hidden: int = 128,
+        steps: int = 1,
+        learning_rate: float = 0.001,
+        momentum: float = 0.0,
+        decay: float = 0.0,
+        temperature: float = 1.0,
+        use_gpu: bool = False,
+    ) -> None:
+        """Initialization method.
+
+        Note: learning_rate defaults to 0.001 (lower than RTRBM's 0.1)
+        following Cho et al. 2011's finding that GBRBMs are very sensitive
+        to learning rate -- use a small rate and anneal if needed.
+
+        Args mirror VarianceGaussianRBM.__init__ (gaussian_rbm.py) plus
+        the recurrent parameters added by RTRBM.__init__ (W_prime, h0).
+        """
+        logger.info("Overriding class: RTRBM -> RTVarianceGaussianRBM.")
+
+        super(RTVarianceGaussianRBM, self).__init__(
+            n_visible,
+            n_hidden,
+            steps,
+            learning_rate,
+            momentum,
+            decay,
+            temperature,
+            use_gpu,
+        )
+
+        # Per-feature learned variance, initialized to 1.0 --
+        # matches VarianceGaussianRBM's initialization exactly.
+        # Registered with optimizer via add_param_group, same pattern
+        # as W_prime and h0 in RTRBM.__init__ and sigma in
+        # VarianceGaussianRBM.__init__ (gaussian_rbm.py line 525-526).
+        self.sigma = nn.Parameter(torch.ones(n_visible))
+        self.optimizer.add_param_group({"params": self.sigma})
+
+        if self.device == "cuda":
+            self.cuda()
+
+        logger.info("Class overrided.")
+
+    @property
+    def sigma(self) -> torch.nn.Parameter:
+        """Per-feature learned standard deviation parameter."""
+        return self._sigma
+
+    @sigma.setter
+    def sigma(self, sigma: torch.nn.Parameter) -> None:
+        self._sigma = sigma
+
+    def hidden_sampling(
+        self, v: torch.Tensor, h_prev: torch.Tensor, scale: bool = False
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Performs hidden layer sampling P(h_t | v_t, h_{t-1}).
+
+        Overrides RTRBM.hidden_sampling to scale v by sigma^2 before
+        the linear transform, per Cho et al. 2011 eq. 2:
+            p(h_j=1 | v) = sigmoid(c_j + sum_i W_ij * v_i / sigma_i^2)
+
+        Mirrors VarianceGaussianRBM.hidden_sampling (gaussian_rbm.py
+        lines 557-568) with the addition of the recurrent bias term
+        W_prime @ h_prev, same as RTRBM.hidden_sampling.
+
+        Args:
+            v: Visible layer tensor, shape (batch, n_visible).
+            h_prev: Previous hidden probabilities, shape (batch, n_hidden).
+            scale: Whether to divide by temperature T.
+
+        Returns:
+            (probs, states) of the hidden layer.
+        """
+        # Divide v by sigma^2 before the linear transform --
+        # matches VarianceGaussianRBM.hidden_sampling exactly,
+        # plus adds the recurrent bias term from RTRBM.
+        sigma_sq = torch.pow(self.sigma, 2) + c.EPSILON
+        v_scaled = torch.div(v, sigma_sq)
+
+        recurrent_bias = F.linear(h_prev, self.W_prime, self.b)
+        activations = F.linear(v_scaled, self.W.t()) + recurrent_bias
+
+        if scale:
+            probs = torch.sigmoid(torch.div(activations, self.T))
+        else:
+            probs = torch.sigmoid(activations)
+
+        # Clamp for numerical stability -- same guard used in RTGaussianRBM
+        probs = torch.clamp(probs, 1e-6, 1 - 1e-6)
+        states = torch.bernoulli(probs)
+
+        return probs, states
+
+    def visible_sampling(
+        self, h: torch.Tensor, scale: bool = False
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Performs visible layer sampling P(v|h).
+
+        Mirrors VarianceGaussianRBM.visible_sampling (gaussian_rbm.py
+        lines 570-595) exactly:
+            p(v_i | h) = N(a_i + sum_j W_ij * h_j, sigma_i^2)
+
+        Samples from Normal(mean, sigma^2) using torch.normal.
+
+        IMPORTANT: return order is (states, activations) -- REVERSED
+        compared to GaussianRBM.visible_sampling which returns
+        (probs, states). This matches VarianceGaussianRBM's convention
+        exactly, which must be consistent throughout gibbs_sampling
+        and reconstruct.
+
+        Args:
+            h: Hidden layer tensor, shape (batch, n_hidden).
+            scale: Whether to divide by temperature T.
+
+        Returns:
+            (states, activations): states are samples from N(mean, sigma^2),
+            activations are the means W*h + a.
+        """
+        activations = F.linear(h, self.W, self.a)
+
+        if self.device == "cpu":
+            # Variance needs shape (batch_size, n_visible) on CPU
+            # Mirrors VarianceGaussianRBM.visible_sampling lines 586-591
+            sigma = self.sigma.unsqueeze(0).expand(activations.size(0), -1)
+        else:
+            sigma = self.sigma
+
+        states = torch.normal(activations, torch.pow(sigma, 2))
+
+        # Return (states, activations) -- same order as VarianceGaussianRBM
+        return states, activations
+
+    def energy(
+        self, samples: torch.Tensor, h_prev: torch.Tensor
+    ) -> torch.Tensor:
+        """Calculates the system's energy with learned variance.
+
+        Mirrors VarianceGaussianRBM.energy (gaussian_rbm.py lines 597-619)
+        with the addition of the recurrent bias term from RTRBM.energy:
+            E = sum_i (v_i - a_i)^2 / (2*sigma_i^2)
+              - sum_j softplus(sum_i W_ij*v_i/sigma_i^2 + W'h_prev + b)
+
+        Args:
+            samples: Visible samples, shape (batch, n_visible).
+            h_prev: Previous hidden probabilities, shape (batch, n_hidden).
+
+        Returns:
+            System energy per sample, shape (batch,).
+        """
+        sigma_sq = torch.pow(self.sigma, 2) + c.EPSILON
+        v_scaled = torch.div(samples, sigma_sq)
+
+        # Recurrent bias term -- same as RTRBM.energy
+        recurrent_bias = F.linear(h_prev, self.W_prime, self.b)
+        activations = F.linear(v_scaled, self.W.t()) + recurrent_bias
+
+        s = nn.Softplus()
+        h = torch.sum(s(activations), dim=1)
+
+        # Quadratic visible term with learned variance --
+        # matches VarianceGaussianRBM.energy line 615 exactly
+        v = torch.sum(
+            torch.div(torch.pow(samples - self.a, 2), 2 * sigma_sq), dim=1
+        )
+
+        energy = -v - h
+
+        return energy
+
+    def gibbs_sampling(
+        self, v: torch.Tensor, h_prev: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Performs Gibbs sampling for one timestep with learned variance.
+
+        Mirrors RTRBM.gibbs_sampling but uses visible_sampling's
+        (states, activations) return convention from VarianceGaussianRBM:
+        passes activations (the mean) back into hidden_sampling during
+        the CD-k loop, NOT the noisy sampled states.
+
+        Using the mean (activations) rather than noisy samples during
+        the Gibbs loop is the standard approach for Gaussian visible units
+        per Hinton & Salakhutdinov (2006): "rather than sampling from the
+        distribution, the visible units can be set equal to their means."
+        This prevents activation explosion during the bouncing steps.
+        """
+        pos_hidden_probs, pos_hidden_states = self.hidden_sampling(v, h_prev)
+        neg_hidden_states = pos_hidden_states
+
+        for _ in range(self.steps):
+            # visible_sampling returns (states, activations) for
+            # VarianceGaussianRBM -- use activations (mean) not states
+            # (noisy sample) to feed back into hidden_sampling
+            visible_states, visible_activations = self.visible_sampling(
+                neg_hidden_states, True
+            )
+            neg_hidden_probs, neg_hidden_states = self.hidden_sampling(
+                visible_activations, h_prev, True
+            )
+
+        # Return activations (mean) as visible_states for energy computation
+        # -- consistent with using the mean throughout Gibbs sampling
+        return (
+            pos_hidden_probs,
+            pos_hidden_states,
+            neg_hidden_probs,
+            neg_hidden_states,
+            visible_activations,
+        )
+
+    def fit_subseries(self, sequence: torch.Tensor) -> torch.Tensor:
+        """Trains on one subseries with learned variance.
+
+        No per-batch normalization needed -- sigma learns the scale
+        of each feature. Otherwise identical to RTRBM.fit_subseries:
+        accumulate cost across all timesteps, single backward/step.
+
+        Gradient clipping included for stability, following
+        Melchior et al. (2017)'s recommendation for GRBM training.
+        """
+        batch_size, seq_len, n_visible = sequence.shape
+        h_prev = self.h0.unsqueeze(0).expand(batch_size, -1)
+
+        self.optimizer.zero_grad()
+
+        total_cost = torch.tensor(0.0)
+        total_mse = torch.tensor(0.0)
+
+        for t in range(seq_len):
+            v_t = sequence[:, t, :]
+            _, _, _, _, visible_activations = self.gibbs_sampling(v_t, h_prev)
+            visible_activations = visible_activations.detach()
+
+            cost_t = torch.mean(self.energy(v_t, h_prev)) - torch.mean(
+                self.energy(visible_activations, h_prev)
+            )
+            total_cost = total_cost + cost_t
+
+            batch_mse = torch.div(
+                torch.sum(torch.pow(v_t - visible_activations, 2)), batch_size
+            ).detach()
+            total_mse = total_mse + batch_mse
+
+            h_prev, _ = self.hidden_sampling(v_t, h_prev)
+            h_prev = torch.nan_to_num(h_prev, nan=0.5)
+            h_prev = torch.clamp(h_prev, 0.0, 1.0)
+
+        total_cost.backward()
+
+        # Gradient clipping -- important for GRBM stability
+        # per Melchior et al. (2017) "Gaussian-Bernoulli RBMs Without Tears"
+        torch.nn.utils.clip_grad_norm_(self.parameters(), max_norm=1.0)
+
+        self.optimizer.step()
+
+        return total_mse
+
+    def reconstruct(
+        self, dataset: torch.utils.data.Dataset
+    ) -> Tuple[float, torch.Tensor]:
+        """Reconstructs batches of sequences.
+
+        No normalization during reconstruction -- unlike RTGaussianRBM,
+        the model works in the original data space since sigma handles
+        the per-feature scaling. Mirrors RTRBM.reconstruct's structure
+        but uses visible_sampling's (states, activations) convention
+        and returns the mean activations (not noisy states) as the
+        reconstruction, per standard GRBM practice.
+        """
+        from torch.utils.data import DataLoader
+        from tqdm import tqdm
+
+        logger.info("Reconstructing new samples ...")
+
+        mse = torch.tensor(0.0)
+        batch_size = len(dataset)
+        batches = DataLoader(
+            dataset, batch_size=batch_size, shuffle=False, num_workers=0
+        )
+        visible_probs_all = []
+
+        for samples, _ in tqdm(batches):
+            if self.device == "cuda":
+                samples = samples.cuda()
+
+            batch_size_actual = samples.size(0)
+            seq_len = samples.size(1)
+            h_prev = self.h0.unsqueeze(0).expand(batch_size_actual, -1)
+
+            recon_activations = []
+
+            for t in range(seq_len):
+                v_t = samples[:, t, :]
+                pos_hidden_probs, pos_hidden_states = self.hidden_sampling(
+                    v_t, h_prev
+                )
+                # visible_sampling returns (states, activations)
+                _, visible_activations = self.visible_sampling(
+                    pos_hidden_states)
+                recon_activations.append(visible_activations.unsqueeze(1))
+                h_prev = pos_hidden_probs
+
+            recon_seq = torch.cat(recon_activations, dim=1)
+
+            batch_mse = torch.div(
+                torch.sum(torch.pow(samples - recon_seq, 2)),
+                batch_size_actual
+            ).detach()
+            mse += batch_mse
+            visible_probs_all.append(recon_seq)
+
+        mse /= len(batches)
+        logger.info("MSE: %f", mse)
+
+        return mse, torch.cat(visible_probs_all, dim=0)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Performs a forward pass over the data.
+
+        No input normalization needed -- sigma handles per-feature scaling.
+        Otherwise mirrors RTRBM.forward exactly.
+
+        Args:
+            x: Input tensor of shape (batch, seq_len, n_visible).
+
+        Returns:
+            Hidden probability sequence, shape (batch, seq_len, n_hidden).
+        """
+        batch_size, seq_len, n_visible = x.shape
+        h_prev = self.h0.unsqueeze(0).expand(batch_size, -1)
+
+        all_probs = []
+        for t in range(seq_len):
+            v_t = x[:, t, :]
+            probs, _ = self.hidden_sampling(v_t, h_prev)
+            all_probs.append(probs.unsqueeze(1))
+            h_prev = probs
+
+        return torch.cat(all_probs, dim=1)

--- a/learnergy/models/temporal/rt_variance_gaussian_rbm.py
+++ b/learnergy/models/temporal/rt_variance_gaussian_rbm.py
@@ -5,11 +5,6 @@ learnergy's VarianceGaussianRBM (gaussian_rbm.py) exactly. No per-batch
 normalization required -- the model learns the variance of each feature
 directly from data, making it suitable for biomechanical time series where
 different features have genuinely different scales.
-
-This directly addresses the limitation observed with RTGaussianRBM where
-low-variance features (e.g. features 1 and 3 in the reach data) were
-reconstructed as flat lines because per-batch normalization assumed unit
-variance for all features.
 """
 from typing import Tuple
 
@@ -29,16 +24,7 @@ class RTVarianceGaussianRBM(RTRBM):
 
     Extends RTRBM by adding a learnable sigma parameter (one per visible
     feature), following VarianceGaussianRBM in learnergy's gaussian_rbm.py
-    exactly. No per-batch normalization needed -- sigma learns the scale
-    of each feature automatically.
-
-    Key differences from RTGaussianRBM:
-    - No normalize/input_normalize flags -- sigma replaces normalization
-    - hidden_sampling divides v by sigma^2 (per Cho et al. 2011 eq. 2)
-    - visible_sampling samples from N(W*h + a, sigma^2) using torch.normal
-    - energy uses quadratic term (v-a)^2 / (2*sigma^2) scaled by learned variance
-    - visible_sampling returns (states, activations) -- REVERSED vs GaussianRBM,
-      matching VarianceGaussianRBM's convention exactly
+    exactly.
 
     Training note (from Cho et al. 2011, Fig 1b): learning diverges if
     sigma is updated from epoch 1 with a large learning rate. We provide
@@ -60,13 +46,6 @@ class RTVarianceGaussianRBM(RTRBM):
         use_gpu: bool = False,
     ) -> None:
         """Initialization method.
-
-        Note: learning_rate defaults to 0.001 (lower than RTRBM's 0.1)
-        following Cho et al. 2011's finding that GBRBMs are very sensitive
-        to learning rate -- use a small rate and anneal if needed.
-
-        Args mirror VarianceGaussianRBM.__init__ (gaussian_rbm.py) plus
-        the recurrent parameters added by RTRBM.__init__ (W_prime, h0).
         """
         logger.info("Overriding class: RTRBM -> RTVarianceGaussianRBM.")
 
@@ -111,18 +90,6 @@ class RTVarianceGaussianRBM(RTRBM):
         Overrides RTRBM.hidden_sampling to scale v by sigma^2 before
         the linear transform, per Cho et al. 2011 eq. 2:
             p(h_j=1 | v) = sigmoid(c_j + sum_i W_ij * v_i / sigma_i^2)
-
-        Mirrors VarianceGaussianRBM.hidden_sampling (gaussian_rbm.py
-        lines 557-568) with the addition of the recurrent bias term
-        W_prime @ h_prev, same as RTRBM.hidden_sampling.
-
-        Args:
-            v: Visible layer tensor, shape (batch, n_visible).
-            h_prev: Previous hidden probabilities, shape (batch, n_hidden).
-            scale: Whether to divide by temperature T.
-
-        Returns:
-            (probs, states) of the hidden layer.
         """
         # Divide v by sigma^2 before the linear transform --
         # matches VarianceGaussianRBM.hidden_sampling exactly,
@@ -147,28 +114,6 @@ class RTVarianceGaussianRBM(RTRBM):
     def visible_sampling(
         self, h: torch.Tensor, scale: bool = False
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        """Performs visible layer sampling P(v|h).
-
-        Mirrors VarianceGaussianRBM.visible_sampling (gaussian_rbm.py
-        lines 570-595) exactly:
-            p(v_i | h) = N(a_i + sum_j W_ij * h_j, sigma_i^2)
-
-        Samples from Normal(mean, sigma^2) using torch.normal.
-
-        IMPORTANT: return order is (states, activations) -- REVERSED
-        compared to GaussianRBM.visible_sampling which returns
-        (probs, states). This matches VarianceGaussianRBM's convention
-        exactly, which must be consistent throughout gibbs_sampling
-        and reconstruct.
-
-        Args:
-            h: Hidden layer tensor, shape (batch, n_hidden).
-            scale: Whether to divide by temperature T.
-
-        Returns:
-            (states, activations): states are samples from N(mean, sigma^2),
-            activations are the means W*h + a.
-        """
         activations = F.linear(h, self.W, self.a)
 
         if self.device == "cpu":
@@ -186,20 +131,6 @@ class RTVarianceGaussianRBM(RTRBM):
     def energy(
         self, samples: torch.Tensor, h_prev: torch.Tensor
     ) -> torch.Tensor:
-        """Calculates the system's energy with learned variance.
-
-        Mirrors VarianceGaussianRBM.energy (gaussian_rbm.py lines 597-619)
-        with the addition of the recurrent bias term from RTRBM.energy:
-            E = sum_i (v_i - a_i)^2 / (2*sigma_i^2)
-              - sum_j softplus(sum_i W_ij*v_i/sigma_i^2 + W'h_prev + b)
-
-        Args:
-            samples: Visible samples, shape (batch, n_visible).
-            h_prev: Previous hidden probabilities, shape (batch, n_hidden).
-
-        Returns:
-            System energy per sample, shape (batch,).
-        """
         sigma_sq = torch.pow(self.sigma, 2) + c.EPSILON
         v_scaled = torch.div(samples, sigma_sq)
 
@@ -229,12 +160,6 @@ class RTVarianceGaussianRBM(RTRBM):
         (states, activations) return convention from VarianceGaussianRBM:
         passes activations (the mean) back into hidden_sampling during
         the CD-k loop, NOT the noisy sampled states.
-
-        Using the mean (activations) rather than noisy samples during
-        the Gibbs loop is the standard approach for Gaussian visible units
-        per Hinton & Salakhutdinov (2006): "rather than sampling from the
-        distribution, the visible units can be set equal to their means."
-        This prevents activation explosion during the bouncing steps.
         """
         pos_hidden_probs, pos_hidden_states = self.hidden_sampling(v, h_prev)
         neg_hidden_states = pos_hidden_states
@@ -262,13 +187,6 @@ class RTVarianceGaussianRBM(RTRBM):
 
     def fit_subseries(self, sequence: torch.Tensor) -> torch.Tensor:
         """Trains on one subseries with learned variance.
-
-        No per-batch normalization needed -- sigma learns the scale
-        of each feature. Otherwise identical to RTRBM.fit_subseries:
-        accumulate cost across all timesteps, single backward/step.
-
-        Gradient clipping included for stability, following
-        Melchior et al. (2017)'s recommendation for GRBM training.
         """
         batch_size, seq_len, n_visible = sequence.shape
         h_prev = self.h0.unsqueeze(0).expand(batch_size, -1)
@@ -311,13 +229,6 @@ class RTVarianceGaussianRBM(RTRBM):
         self, dataset: torch.utils.data.Dataset
     ) -> Tuple[float, torch.Tensor]:
         """Reconstructs batches of sequences.
-
-        No normalization during reconstruction -- unlike RTGaussianRBM,
-        the model works in the original data space since sigma handles
-        the per-feature scaling. Mirrors RTRBM.reconstruct's structure
-        but uses visible_sampling's (states, activations) convention
-        and returns the mean activations (not noisy states) as the
-        reconstruction, per standard GRBM practice.
         """
         from torch.utils.data import DataLoader
         from tqdm import tqdm
@@ -368,15 +279,6 @@ class RTVarianceGaussianRBM(RTRBM):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Performs a forward pass over the data.
-
-        No input normalization needed -- sigma handles per-feature scaling.
-        Otherwise mirrors RTRBM.forward exactly.
-
-        Args:
-            x: Input tensor of shape (batch, seq_len, n_visible).
-
-        Returns:
-            Hidden probability sequence, shape (batch, seq_len, n_hidden).
         """
         batch_size, seq_len, n_visible = x.shape
         h_prev = self.h0.unsqueeze(0).expand(batch_size, -1)

--- a/learnergy/models/temporal/rt_variance_gaussian_rbm.py
+++ b/learnergy/models/temporal/rt_variance_gaussian_rbm.py
@@ -1,10 +1,7 @@
 """Recurrent Temporal Restricted Boltzmann Machine with Learned Variance.
 
 Extends RTRBM with per-feature learned variance (sigma), following
-learnergy's VarianceGaussianRBM (gaussian_rbm.py) exactly. No per-batch
-normalization required -- the model learns the variance of each feature
-directly from data, making it suitable for biomechanical time series where
-different features have genuinely different scales.
+learnergy's VarianceGaussianRBM (gaussian_rbm.py) exactly.
 """
 from typing import Tuple
 
@@ -25,13 +22,6 @@ class RTVarianceGaussianRBM(RTRBM):
     Extends RTRBM by adding a learnable sigma parameter (one per visible
     feature), following VarianceGaussianRBM in learnergy's gaussian_rbm.py
     exactly.
-
-    Training note (from Cho et al. 2011, Fig 1b): learning diverges if
-    sigma is updated from epoch 1 with a large learning rate. We provide
-    a `train_sigma` flag so sigma can be frozen initially (warmup period)
-    and then enabled once W/a/b have stabilized. Recommended:
-        - Warmup: train_sigma=False for ~10-20 epochs
-        - Then: train_sigma=True for remaining epochs
     """
 
     def __init__(
@@ -60,11 +50,6 @@ class RTVarianceGaussianRBM(RTRBM):
             use_gpu,
         )
 
-        # Per-feature learned variance, initialized to 1.0 --
-        # matches VarianceGaussianRBM's initialization exactly.
-        # Registered with optimizer via add_param_group, same pattern
-        # as W_prime and h0 in RTRBM.__init__ and sigma in
-        # VarianceGaussianRBM.__init__ (gaussian_rbm.py line 525-526).
         self.sigma = nn.Parameter(torch.ones(n_visible))
         self.optimizer.add_param_group({"params": self.sigma})
 
@@ -85,12 +70,6 @@ class RTVarianceGaussianRBM(RTRBM):
     def hidden_sampling(
         self, v: torch.Tensor, h_prev: torch.Tensor, scale: bool = False
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        """Performs hidden layer sampling P(h_t | v_t, h_{t-1}).
-
-        Overrides RTRBM.hidden_sampling to scale v by sigma^2 before
-        the linear transform, per Cho et al. 2011 eq. 2:
-            p(h_j=1 | v) = sigmoid(c_j + sum_i W_ij * v_i / sigma_i^2)
-        """
         # Divide v by sigma^2 before the linear transform --
         # matches VarianceGaussianRBM.hidden_sampling exactly,
         # plus adds the recurrent bias term from RTRBM.
@@ -105,7 +84,6 @@ class RTVarianceGaussianRBM(RTRBM):
         else:
             probs = torch.sigmoid(activations)
 
-        # Clamp for numerical stability -- same guard used in RTGaussianRBM
         probs = torch.clamp(probs, 1e-6, 1 - 1e-6)
         states = torch.bernoulli(probs)
 
@@ -117,15 +95,12 @@ class RTVarianceGaussianRBM(RTRBM):
         activations = F.linear(h, self.W, self.a)
 
         if self.device == "cpu":
-            # Variance needs shape (batch_size, n_visible) on CPU
-            # Mirrors VarianceGaussianRBM.visible_sampling lines 586-591
             sigma = self.sigma.unsqueeze(0).expand(activations.size(0), -1)
         else:
             sigma = self.sigma
 
         states = torch.normal(activations, torch.pow(sigma, 2))
 
-        # Return (states, activations) -- same order as VarianceGaussianRBM
         return states, activations
 
     def energy(
@@ -134,15 +109,12 @@ class RTVarianceGaussianRBM(RTRBM):
         sigma_sq = torch.pow(self.sigma, 2) + c.EPSILON
         v_scaled = torch.div(samples, sigma_sq)
 
-        # Recurrent bias term -- same as RTRBM.energy
         recurrent_bias = F.linear(h_prev, self.W_prime, self.b)
         activations = F.linear(v_scaled, self.W.t()) + recurrent_bias
 
         s = nn.Softplus()
         h = torch.sum(s(activations), dim=1)
 
-        # Quadratic visible term with learned variance --
-        # matches VarianceGaussianRBM.energy line 615 exactly
         v = torch.sum(
             torch.div(torch.pow(samples - self.a, 2), 2 * sigma_sq), dim=1
         )
@@ -155,19 +127,11 @@ class RTVarianceGaussianRBM(RTRBM):
         self, v: torch.Tensor, h_prev: torch.Tensor
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
         """Performs Gibbs sampling for one timestep with learned variance.
-
-        Mirrors RTRBM.gibbs_sampling but uses visible_sampling's
-        (states, activations) return convention from VarianceGaussianRBM:
-        passes activations (the mean) back into hidden_sampling during
-        the CD-k loop, NOT the noisy sampled states.
         """
         pos_hidden_probs, pos_hidden_states = self.hidden_sampling(v, h_prev)
         neg_hidden_states = pos_hidden_states
 
         for _ in range(self.steps):
-            # visible_sampling returns (states, activations) for
-            # VarianceGaussianRBM -- use activations (mean) not states
-            # (noisy sample) to feed back into hidden_sampling
             visible_states, visible_activations = self.visible_sampling(
                 neg_hidden_states, True
             )
@@ -175,8 +139,6 @@ class RTVarianceGaussianRBM(RTRBM):
                 visible_activations, h_prev, True
             )
 
-        # Return activations (mean) as visible_states for energy computation
-        # -- consistent with using the mean throughout Gibbs sampling
         return (
             pos_hidden_probs,
             pos_hidden_states,
@@ -218,7 +180,6 @@ class RTVarianceGaussianRBM(RTRBM):
         total_cost.backward()
 
         # Gradient clipping -- important for GRBM stability
-        # per Melchior et al. (2017) "Gaussian-Bernoulli RBMs Without Tears"
         torch.nn.utils.clip_grad_norm_(self.parameters(), max_norm=1.0)
 
         self.optimizer.step()
@@ -257,7 +218,6 @@ class RTVarianceGaussianRBM(RTRBM):
                 pos_hidden_probs, pos_hidden_states = self.hidden_sampling(
                     v_t, h_prev
                 )
-                # visible_sampling returns (states, activations)
                 _, visible_activations = self.visible_sampling(
                     pos_hidden_states)
                 recon_activations.append(visible_activations.unsqueeze(1))

--- a/learnergy/models/temporal/rtdbn.py
+++ b/learnergy/models/temporal/rtdbn.py
@@ -3,7 +3,11 @@
 - Each layer is an RTRBM (specifically RTVarianceGaussianRBM by default)
 - forward() returns temporal embeddings via mean pooling over the time
   axis, collapsing (batch, seq_len, n_hidden) -> (batch, n_hidden)
-- fit() trains each layer on sequences rather than flat vectors
+- fit() trains each layer on sequences
+
+Clustering head and training wrapper live in SIT-FUSE:
+  sit_fuse.models.encoders.rtdbn_pl (encoder wrapper)
+  sit_fuse.models.deep_cluster.rtdbn_dc (clustering head + IIC loss)
 """
 from typing import List, Optional, Tuple
 
@@ -27,51 +31,6 @@ RT_MODELS = {
 }
 
 
-class IICClusteringHead(nn.Module):
-
-    def __init__(
-        self,
-        n_input: int,
-        n_clusters: int,
-        n_hidden: int = 256,
-        noise_std: float = 0.1,
-    ) -> None:
-        super(IICClusteringHead, self).__init__()
-
-        self.noise_std = noise_std
-
-        self.fc = nn.Sequential(
-            nn.Linear(n_input, n_hidden),
-            nn.ReLU(),
-            nn.Linear(n_hidden, n_clusters),
-            nn.Softmax(dim=1),
-        )
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return self.fc(x)
-
-    def perturb(self, x: torch.Tensor) -> torch.Tensor:
-        return x + torch.randn_like(x) * self.noise_std
-
-    @staticmethod
-    def iic_loss(p: torch.Tensor, p_perturbed: torch.Tensor, eps: float = 1e-6) -> torch.Tensor:
-        """Computes the IIC loss (negative mutual information).
-        """
-        p_joint = torch.einsum("bi,bj->ij", p, p_perturbed) / p.shape[0]
-        p_joint = (p_joint + p_joint.t()) / 2  # symmetrize
-        p_joint = torch.clamp(p_joint, min=eps)
-
-        # Marginal distributions
-        p_i = p_joint.sum(dim=1, keepdim=True)  # (n_clusters, 1)
-        p_j = p_joint.sum(dim=0, keepdim=True)  # (1, n_clusters)
-
-        # Mutual information
-        mi = (p_joint * (torch.log(p_joint) -
-              torch.log(p_i) - torch.log(p_j))).sum()
-
-        return -mi
-
-
 class RTDBN(Model):
 
     def __init__(
@@ -85,9 +44,6 @@ class RTDBN(Model):
         decay: Tuple[float, ...] = (0.0,),
         temperature: Tuple[float, ...] = (1.0,),
         use_gpu: bool = False,
-        n_clusters: int = 10,
-        cluster_hidden: int = 256,
-        noise_std: float = 0.1,
     ) -> None:
         logger.info("Overriding class: Model -> RTDBN.")
 
@@ -106,7 +62,6 @@ class RTDBN(Model):
         if not isinstance(model, tuple):
             model = (model,)
 
-        # Build RTRBM layers -- mirrors DBN's nn.ModuleList pattern
         self.models = nn.ModuleList([])
         for i in range(self.n_layers):
             n_input = self.n_visible if i == 0 else self.n_hidden[i - 1]
@@ -128,13 +83,6 @@ class RTDBN(Model):
                 use_gpu=use_gpu,
             )
             self.models.append(m)
-
-        self.clustering_head = IICClusteringHead(
-            n_input=self.n_hidden[-1],
-            n_clusters=n_clusters,
-            n_hidden=cluster_hidden,
-            noise_std=noise_std,
-        )
 
         if self.device == "cuda":
             self.cuda()
@@ -171,18 +119,32 @@ class RTDBN(Model):
         self._n_layers = n_layers
 
     def encode(self, x: torch.Tensor) -> torch.Tensor:
+        """Encodes sequences through all RTRBM layers and returns
+        temporal embeddings via mean pooling over the time axis.
+
+        Args:
+            x: Input sequences, shape (batch, seq_len, n_visible).
+
+        Returns:
+            Temporal embeddings, shape (batch, n_hidden[-1]).
+        """
         h = x
         for model in self.models:
             h = model.forward(h)  # (batch, seq_len, n_hidden_i)
 
-        embedding = h.mean(dim=1)
+        # Mean pool over time: (batch, seq_len, n_hidden) -> (batch, n_hidden)
+        return h.mean(dim=1)
 
-        return embedding
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Full forward pass returning temporal embeddings.
 
-    def forward(self, x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
-        embeddings = self.encode(x)
-        cluster_probs = self.clustering_head(embeddings)
-        return embeddings, cluster_probs
+        Args:
+            x: Input sequences, shape (batch, seq_len, n_visible).
+
+        Returns:
+            Temporal embeddings, shape (batch, n_hidden[-1]).
+        """
+        return self.encode(x)
 
     def fit(
         self,
@@ -191,6 +153,17 @@ class RTDBN(Model):
         epochs: Tuple[int, ...] = (30,),
         warmup_epochs: Tuple[int, ...] = (15,),
     ) -> List[torch.Tensor]:
+        """Trains each RTRBM layer sequentially.
+
+        Args:
+            dataset: Dataset where each sample is (seq_len, n_visible).
+            batch_size: Batch size.
+            epochs: Training epochs per layer.
+            warmup_epochs: Sigma warmup epochs per layer.
+
+        Returns:
+            List of final MSE per layer.
+        """
         if len(epochs) != self.n_layers:
             raise e.SizeError(
                 f"`epochs` should have size equal to {self.n_layers}"
@@ -202,7 +175,6 @@ class RTDBN(Model):
             logger.info("Fitting RTDBN layer %d/%d ...", i + 1, self.n_layers)
 
             if i == 0:
-                # First layer trains on raw sequences
                 warmup = warmup_epochs[i] if i < len(warmup_epochs) else 0
                 full = epochs[i] - warmup
 
@@ -218,131 +190,7 @@ class RTDBN(Model):
             else:
                 raise NotImplementedError(
                     "Multi-layer RTDBN training not yet implemented. "
-                    "(n_hidden=(64,)) -- this error should not appear "
-                    "in the single-layer configuration."
+                    "Use n_hidden=(64,) for the single-layer configuration."
                 )
 
         return mse_per_layer
-
-    def fit_clustering_head(
-        self,
-        dataset: torch.utils.data.Dataset,
-        batch_size: int = 32,
-        epochs: int = 20,
-        learning_rate: float = 0.001,
-    ) -> List[float]:
-        """Trains the IIC clustering head on top of the frozen RTRBM encoder.
-
-        Mirrors SIT-FUSE: encoder pre-trained first, then frozen,
-        then clustering head trained with IIC loss. Perturbations are Gaussian
-        noise added to encoder outputs.
-        """
-        for model in self.models:
-            for param in model.parameters():
-                param.requires_grad_(False)
-
-        optimizer = torch.optim.Adam(
-            self.clustering_head.parameters(), lr=learning_rate
-        )
-
-        batches = DataLoader(
-            dataset, batch_size=batch_size, shuffle=True, num_workers=0
-        )
-
-        loss_history = []
-
-        for epoch in range(epochs):
-            epoch_loss = 0.0
-            n_batches = 0
-
-            for samples, _ in tqdm(batches, desc=f"IIC epoch {epoch+1}/{epochs}"):
-                if self.device == "cuda":
-                    samples = samples.cuda()
-
-                with torch.no_grad():
-                    embeddings = self.encode(samples)
-
-                emb_std = embeddings.std().item()
-                adaptive_noise = max(emb_std * 0.1, 1e-4)
-
-                perturbed = embeddings + \
-                    torch.randn_like(embeddings) * adaptive_noise
-
-                p = self.clustering_head(embeddings.detach())
-                p_perturbed = self.clustering_head(perturbed.detach())
-
-                # IIC loss
-                loss = IICClusteringHead.iic_loss(p, p_perturbed)
-
-                optimizer.zero_grad()
-                loss.backward()
-                optimizer.step()
-
-                epoch_loss += loss.item()
-                n_batches += 1
-
-            avg_loss = epoch_loss / n_batches
-            loss_history.append(avg_loss)
-            self.dump(iic_loss=avg_loss)
-
-            logger.info("IIC Epoch %d/%d | Loss: %.4f",
-                        epoch + 1, epochs, avg_loss)
-
-        # Unfreeze encoder after clustering head training
-        for model in self.models:
-            for param in model.parameters():
-                param.requires_grad_(True)
-
-        return loss_history
-
-    def fit_clustering_kmeans(
-        self,
-        dataset: torch.utils.data.Dataset,
-        batch_size: int = 32,
-        n_init: int = 10,
-    ) -> torch.Tensor:
-        """Clusters temporal embeddings using k-means.
-        """
-        from sklearn.cluster import KMeans
-
-        # Extract all embeddings
-        embeddings, _ = self.get_cluster_assignments(dataset, batch_size)
-        emb_np = embeddings.numpy()
-
-        # Fit k-means
-        km = KMeans(
-            n_clusters=self.clustering_head.fc[-2].out_features,
-            n_init=n_init,
-            random_state=42,
-        )
-        assignments = km.fit_predict(emb_np)
-
-        return torch.from_numpy(assignments)
-
-    def get_cluster_assignments(
-        self, dataset: torch.utils.data.Dataset, batch_size: int = 32
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
-        """Returns cluster assignments and embeddings for a full dataset.
-        """
-        batches = DataLoader(
-            dataset, batch_size=batch_size, shuffle=False, num_workers=0
-        )
-
-        all_embeddings = []
-        all_assignments = []
-
-        with torch.no_grad():
-            for samples, _ in tqdm(batches):
-                if self.device == "cuda":
-                    samples = samples.cuda()
-
-                embeddings, cluster_probs = self.forward(samples)
-                assignments = torch.argmax(cluster_probs, dim=1)
-
-                all_embeddings.append(embeddings)
-                all_assignments.append(assignments)
-
-        return (
-            torch.cat(all_embeddings, dim=0),
-            torch.cat(all_assignments, dim=0),
-        )

--- a/learnergy/models/temporal/rtdbn.py
+++ b/learnergy/models/temporal/rtdbn.py
@@ -22,8 +22,6 @@ from learnergy.models.temporal.rt_variance_gaussian_rbm import RTVarianceGaussia
 logger = logging.get_logger(__name__)
 
 
-# Registry of supported RTRBM types -- mirrors DBN's MODELS dict (dbn.py)
-# so additional RTRBM variants can be added later without changing RTDBN.
 RT_MODELS = {
     "variance_gaussian": RTVarianceGaussianRBM,
 }
@@ -42,8 +40,6 @@ class IICClusteringHead(nn.Module):
 
         self.noise_std = noise_std
 
-        # Two fully connected layers -- same pattern as SIT-FUSE's
-        # clustering head architecture from the paper
         self.fc = nn.Sequential(
             nn.Linear(n_input, n_hidden),
             nn.ReLU(),
@@ -61,8 +57,6 @@ class IICClusteringHead(nn.Module):
     def iic_loss(p: torch.Tensor, p_perturbed: torch.Tensor, eps: float = 1e-6) -> torch.Tensor:
         """Computes the IIC loss (negative mutual information).
         """
-        # Joint distribution P(c, c') -- outer product averaged over batch
-        # Shape: (n_clusters, n_clusters)
         p_joint = torch.einsum("bi,bj->ij", p, p_perturbed) / p.shape[0]
         p_joint = (p_joint + p_joint.t()) / 2  # symmetrize
         p_joint = torch.clamp(p_joint, min=eps)
@@ -71,7 +65,7 @@ class IICClusteringHead(nn.Module):
         p_i = p_joint.sum(dim=1, keepdim=True)  # (n_clusters, 1)
         p_j = p_joint.sum(dim=0, keepdim=True)  # (1, n_clusters)
 
-        # Mutual information (negative, since we minimize loss)
+        # Mutual information
         mi = (p_joint * (torch.log(p_joint) -
               torch.log(p_i) - torch.log(p_j))).sum()
 
@@ -135,8 +129,6 @@ class RTDBN(Model):
             )
             self.models.append(m)
 
-        # IIC clustering head -- takes the temporal embedding from the
-        # last RTRBM layer and produces cluster assignments
         self.clustering_head = IICClusteringHead(
             n_input=self.n_hidden[-1],
             n_clusters=n_clusters,
@@ -179,15 +171,10 @@ class RTDBN(Model):
         self._n_layers = n_layers
 
     def encode(self, x: torch.Tensor) -> torch.Tensor:
-        # Pass through each RTRBM layer sequentially --
-        # mirrors DBN.forward()'s layer-by-layer pattern (dbn.py line 404)
-        # but adapted for temporal (batch, seq_len, n_features) shape
         h = x
         for model in self.models:
             h = model.forward(h)  # (batch, seq_len, n_hidden_i)
 
-        # Mean pool over time axis: (batch, seq_len, n_hidden) -> (batch, n_hidden)
-        # Standard approach for collapsing sequence embeddings to fixed-size vectors
         embedding = h.mean(dim=1)
 
         return embedding
@@ -229,13 +216,6 @@ class RTDBN(Model):
                 mse_per_layer.append(model.history["mse"][-1])
 
             else:
-                # Subsequent layers train on hidden output of previous layers.
-                # We need to transform the dataset by passing it through
-                # all previous layers first -- same principle as DBN.fit()
-                # lines 325-326 which pass samples through previous models.
-                # TODO: implement multi-layer training when n_layers > 1.
-                # For now, Nick said start with one layer -- this path won't
-                # be hit with the default single-layer config.
                 raise NotImplementedError(
                     "Multi-layer RTDBN training not yet implemented. "
                     "(n_hidden=(64,)) -- this error should not appear "
@@ -257,7 +237,6 @@ class RTDBN(Model):
         then clustering head trained with IIC loss. Perturbations are Gaussian
         noise added to encoder outputs.
         """
-        # Freeze the RTRBM encoder -- only train the clustering head
         for model in self.models:
             for param in model.parameters():
                 param.requires_grad_(False)
@@ -280,27 +259,15 @@ class RTDBN(Model):
                 if self.device == "cuda":
                     samples = samples.cuda()
 
-                # Compute embeddings FRESH per batch -- NOT cached.
-                # Encoder is frozen so no grad needed through it,
-                # but embeddings must be computed here (not pre-cached)
-                # so each batch draws from the actual data distribution.
                 with torch.no_grad():
                     embeddings = self.encode(samples)
 
-                # Scale noise relative to embedding magnitude --
-                # fixed noise_std can be too large or too small depending
-                # on the encoder's output scale. Using 10% of per-batch
-                # std keeps perturbations meaningful without destroying signal.
                 emb_std = embeddings.std().item()
                 adaptive_noise = max(emb_std * 0.1, 1e-4)
 
-                # Perturb embeddings (adaptive Gaussian noise)
                 perturbed = embeddings + \
                     torch.randn_like(embeddings) * adaptive_noise
 
-                # Forward pass through clustering head
-                # embeddings.detach() so gradients only flow through
-                # the clustering head, not back to the frozen encoder
                 p = self.clustering_head(embeddings.detach())
                 p_perturbed = self.clustering_head(perturbed.detach())
 
@@ -335,12 +302,6 @@ class RTDBN(Model):
         n_init: int = 10,
     ) -> torch.Tensor:
         """Clusters temporal embeddings using k-means.
-
-        Practical alternative to IIC for initial end-to-end analysis.
-        IIC requires training the encoder jointly with the clustering head
-        to learn discriminative features -- training a clustering head on
-        frozen RTRBM embeddings alone leads to collapse when the embeddings
-        lack sufficient discriminability.
         """
         from sklearn.cluster import KMeans
 

--- a/learnergy/models/temporal/rtdbn.py
+++ b/learnergy/models/temporal/rtdbn.py
@@ -1,15 +1,9 @@
 """Recurrent Temporal Deep Belief Network (RTDBN).
 
-Extends learnergy's DBN (dbn.py) with RTRBMs as the layer type
-instead of plain RBMs, making it suitable for temporal sequence data.
-
 - Each layer is an RTRBM (specifically RTVarianceGaussianRBM by default)
-  rather than a plain RBM -- handles (batch, seq_len, n_visible) input
 - forward() returns temporal embeddings via mean pooling over the time
   axis, collapsing (batch, seq_len, n_hidden) -> (batch, n_hidden)
 - fit() trains each layer on sequences rather than flat vectors
-- Includes a simple IIC-compatible clustering head matching SIT-FUSE's
-  pattern (fully connected layers trained with IIC loss)
 """
 from typing import List, Optional, Tuple
 
@@ -36,16 +30,6 @@ RT_MODELS = {
 
 
 class IICClusteringHead(nn.Module):
-    """Simple IIC-compatible clustering head.
-
-    Matches SIT-FUSE's clustering head pattern: fully connected layers
-    that take the encoder's output and produce soft cluster assignments.
-    Trained using the IIC loss (mutual information between a sample and
-    its perturbed version).
-
-    Per SIT-FUSE paper: perturbations are additions of Gaussian noise
-    to the outputs of RBM-based architectures.
-    """
 
     def __init__(
         self,
@@ -54,13 +38,6 @@ class IICClusteringHead(nn.Module):
         n_hidden: int = 256,
         noise_std: float = 0.1,
     ) -> None:
-        """
-        Args:
-            n_input: Size of the encoder's output (n_hidden of last RTRBM).
-            n_clusters: Number of output clusters.
-            n_hidden: Hidden layer size in the clustering head.
-            noise_std: Std of Gaussian noise used for IIC perturbations.
-        """
         super(IICClusteringHead, self).__init__()
 
         self.noise_std = noise_std
@@ -75,45 +52,14 @@ class IICClusteringHead(nn.Module):
         )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """Returns soft cluster assignments for input embeddings.
-
-        Args:
-            x: Encoder output, shape (batch, n_input).
-
-        Returns:
-            Cluster probabilities, shape (batch, n_clusters).
-        """
         return self.fc(x)
 
     def perturb(self, x: torch.Tensor) -> torch.Tensor:
-        """Adds Gaussian noise to encoder output for IIC perturbation.
-
-        Mirrors SIT-FUSE's perturbation strategy: Gaussian noise added
-        to RBM-based encoder outputs before the clustering head.
-
-        Args:
-            x: Encoder output, shape (batch, n_input).
-
-        Returns:
-            Perturbed encoder output, same shape.
-        """
         return x + torch.randn_like(x) * self.noise_std
 
     @staticmethod
     def iic_loss(p: torch.Tensor, p_perturbed: torch.Tensor, eps: float = 1e-6) -> torch.Tensor:
         """Computes the IIC loss (negative mutual information).
-
-        Maximizes mutual information between cluster assignments of a
-        sample and its perturbed version. Per Ji et al. (2019):
-            I(z; z') = sum_{c,c'} P(c,c') * log[ P(c,c') / (P(c)*P(c')) ]
-
-        Args:
-            p: Cluster probabilities, shape (batch, n_clusters).
-            p_perturbed: Cluster probs for perturbed version, same shape.
-            eps: Small value for numerical stability.
-
-        Returns:
-            Scalar IIC loss (negative mutual information, to minimize).
         """
         # Joint distribution P(c, c') -- outer product averaged over batch
         # Shape: (n_clusters, n_clusters)
@@ -133,14 +79,6 @@ class IICClusteringHead(nn.Module):
 
 
 class RTDBN(Model):
-    """Recurrent Temporal Deep Belief Network.
-
-    Wraps one or more RTRBMs into a deep stack, mirroring learnergy's
-    DBN (dbn.py) structure but adapted for temporal sequences.
-
-    Per Nick's direction: start with one layer. Adding more layers
-    later is just changing n_hidden from (64,) to (64, 32) etc.
-    """
 
     def __init__(
         self,
@@ -157,27 +95,6 @@ class RTDBN(Model):
         cluster_hidden: int = 256,
         noise_std: float = 0.1,
     ) -> None:
-        """Initialization method.
-
-        Mirrors DBN.__init__ (dbn.py) exactly in parameter structure,
-        adapted for RTRBM layer types and the addition of the IIC
-        clustering head.
-
-        Args:
-            model: Tuple of RTRBM type strings, one per layer.
-                   Currently supports: "variance_gaussian".
-            n_visible: Number of visible units (input features).
-            n_hidden: Tuple of hidden unit counts, one per layer.
-            steps: CD-k steps per layer.
-            learning_rate: Learning rate per layer.
-            momentum: Momentum per layer.
-            decay: Weight decay per layer.
-            temperature: Temperature per layer.
-            use_gpu: Whether to use GPU.
-            n_clusters: Number of output clusters for IIC head.
-            cluster_hidden: Hidden size of IIC clustering head.
-            noise_std: Std of Gaussian perturbation noise for IIC.
-        """
         logger.info("Overriding class: Model -> RTDBN.")
 
         super(RTDBN, self).__init__(use_gpu=use_gpu)
@@ -262,20 +179,6 @@ class RTDBN(Model):
         self._n_layers = n_layers
 
     def encode(self, x: torch.Tensor) -> torch.Tensor:
-        """Encodes a sequence through all RTRBM layers and returns a
-        temporal embedding via mean pooling over the time axis.
-
-        This is the key method connecting RTDBN to the IIC clustering
-        head: the (batch, seq_len, n_hidden) output of forward() is
-        collapsed to (batch, n_hidden) by averaging over timesteps,
-        giving one embedding per sequence that can be clustered.
-
-        Args:
-            x: Input sequences, shape (batch, seq_len, n_visible).
-
-        Returns:
-            Temporal embeddings, shape (batch, n_hidden[-1]).
-        """
         # Pass through each RTRBM layer sequentially --
         # mirrors DBN.forward()'s layer-by-layer pattern (dbn.py line 404)
         # but adapted for temporal (batch, seq_len, n_features) shape
@@ -290,16 +193,6 @@ class RTDBN(Model):
         return embedding
 
     def forward(self, x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
-        """Full forward pass: encode sequences and produce cluster assignments.
-
-        Args:
-            x: Input sequences, shape (batch, seq_len, n_visible).
-
-        Returns:
-            (embeddings, cluster_probs):
-            - embeddings: shape (batch, n_hidden[-1]) -- temporal embeddings
-            - cluster_probs: shape (batch, n_clusters) -- soft cluster assignments
-        """
         embeddings = self.encode(x)
         cluster_probs = self.clustering_head(embeddings)
         return embeddings, cluster_probs
@@ -311,23 +204,6 @@ class RTDBN(Model):
         epochs: Tuple[int, ...] = (30,),
         warmup_epochs: Tuple[int, ...] = (15,),
     ) -> List[torch.Tensor]:
-        """Trains each RTRBM layer sequentially, mirroring DBN.fit().
-
-        Layer 0 trains on raw sequences. Each subsequent layer trains
-        on the temporal output of the previous layer -- same greedy
-        layer-wise pre-training as DBN (dbn.py lines 305-341), adapted
-        for sequence data.
-
-        Args:
-            dataset: SFTemporalDataset where each sample is (seq_len, n_visible).
-            batch_size: Batch size.
-            epochs: Training epochs per layer.
-            warmup_epochs: Sigma warmup epochs per layer (only used by
-                RTVarianceGaussianRBM -- number of epochs to freeze sigma).
-
-        Returns:
-            List of final MSE per layer.
-        """
         if len(epochs) != self.n_layers:
             raise e.SizeError(
                 f"`epochs` should have size equal to {self.n_layers}"
@@ -362,7 +238,6 @@ class RTDBN(Model):
                 # be hit with the default single-layer config.
                 raise NotImplementedError(
                     "Multi-layer RTDBN training not yet implemented. "
-                    "Per Nick's direction, start with one layer "
                     "(n_hidden=(64,)) -- this error should not appear "
                     "in the single-layer configuration."
                 )
@@ -378,29 +253,9 @@ class RTDBN(Model):
     ) -> List[float]:
         """Trains the IIC clustering head on top of the frozen RTRBM encoder.
 
-        Mirrors SIT-FUSE's pattern: encoder pre-trained first, then frozen,
+        Mirrors SIT-FUSE: encoder pre-trained first, then frozen,
         then clustering head trained with IIC loss. Perturbations are Gaussian
-        noise added to encoder outputs, per the SIT-FUSE paper.
-
-        KEY FIX vs. original implementation:
-        - Embeddings are computed FRESH per batch inside the training loop,
-          not pre-cached with torch.no_grad(). Pre-caching caused the IIC
-          loss to stay at zero because all batches saw identical deterministic
-          embeddings -- the noise was the only source of variation, making
-          the joint distribution P(c,c') degenerate.
-        - Noise std is scaled RELATIVE to the embedding magnitude (10% of
-          per-batch std) rather than a fixed absolute value. The encoder
-          outputs are small in magnitude; fixed noise_std=0.1 was larger
-          than the entire embedding range, destroying the MI signal.
-
-        Args:
-            dataset: SFTemporalDataset (same as used for RTRBM training).
-            batch_size: Batch size.
-            epochs: Number of IIC training epochs.
-            learning_rate: Learning rate for clustering head optimizer.
-
-        Returns:
-            List of IIC loss values per epoch.
+        noise added to encoder outputs.
         """
         # Freeze the RTRBM encoder -- only train the clustering head
         for model in self.models:
@@ -485,21 +340,7 @@ class RTDBN(Model):
         IIC requires training the encoder jointly with the clustering head
         to learn discriminative features -- training a clustering head on
         frozen RTRBM embeddings alone leads to collapse when the embeddings
-        lack sufficient discriminability (common at early training stages).
-
-        K-means directly on the frozen RTRBM embeddings is a reliable
-        starting point for qualitative analysis, consistent with SIT-FUSE's
-        earlier clustering approach (BIRCH/k-means before transitioning to
-        IIC per the paper). This produces meaningful clusters from whatever
-        structure the RTRBM has learned, without requiring joint training.
-
-        Args:
-            dataset: SFTemporalDataset to cluster.
-            batch_size: Batch size for embedding extraction.
-            n_init: Number of k-means initializations (higher = more stable).
-
-        Returns:
-            Cluster assignment tensor, shape (n_samples,).
+        lack sufficient discriminability.
         """
         from sklearn.cluster import KMeans
 
@@ -521,18 +362,6 @@ class RTDBN(Model):
         self, dataset: torch.utils.data.Dataset, batch_size: int = 32
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         """Returns cluster assignments and embeddings for a full dataset.
-
-        This is the main analysis output -- used to visualize what the
-        model has learned about the structure of the biomechanical data.
-
-        Args:
-            dataset: SFTemporalDataset to cluster.
-            batch_size: Batch size.
-
-        Returns:
-            (embeddings, cluster_assignments):
-            - embeddings: shape (n_samples, n_hidden[-1])
-            - cluster_assignments: shape (n_samples,) -- hard cluster labels
         """
         batches = DataLoader(
             dataset, batch_size=batch_size, shuffle=False, num_workers=0

--- a/learnergy/models/temporal/rtdbn.py
+++ b/learnergy/models/temporal/rtdbn.py
@@ -1,0 +1,558 @@
+"""Recurrent Temporal Deep Belief Network (RTDBN).
+
+Extends learnergy's DBN (dbn.py) with RTRBMs as the layer type
+instead of plain RBMs, making it suitable for temporal sequence data.
+
+- Each layer is an RTRBM (specifically RTVarianceGaussianRBM by default)
+  rather than a plain RBM -- handles (batch, seq_len, n_visible) input
+- forward() returns temporal embeddings via mean pooling over the time
+  axis, collapsing (batch, seq_len, n_hidden) -> (batch, n_hidden)
+- fit() trains each layer on sequences rather than flat vectors
+- Includes a simple IIC-compatible clustering head matching SIT-FUSE's
+  pattern (fully connected layers trained with IIC loss)
+"""
+from typing import List, Optional, Tuple
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.utils.data import DataLoader
+from tqdm import tqdm
+
+import learnergy.utils.exception as e
+from learnergy.core import Model
+from learnergy.utils import logging
+
+from learnergy.models.temporal.rt_variance_gaussian_rbm import RTVarianceGaussianRBM
+
+logger = logging.get_logger(__name__)
+
+
+# Registry of supported RTRBM types -- mirrors DBN's MODELS dict (dbn.py)
+# so additional RTRBM variants can be added later without changing RTDBN.
+RT_MODELS = {
+    "variance_gaussian": RTVarianceGaussianRBM,
+}
+
+
+class IICClusteringHead(nn.Module):
+    """Simple IIC-compatible clustering head.
+
+    Matches SIT-FUSE's clustering head pattern: fully connected layers
+    that take the encoder's output and produce soft cluster assignments.
+    Trained using the IIC loss (mutual information between a sample and
+    its perturbed version).
+
+    Per SIT-FUSE paper: perturbations are additions of Gaussian noise
+    to the outputs of RBM-based architectures.
+    """
+
+    def __init__(
+        self,
+        n_input: int,
+        n_clusters: int,
+        n_hidden: int = 256,
+        noise_std: float = 0.1,
+    ) -> None:
+        """
+        Args:
+            n_input: Size of the encoder's output (n_hidden of last RTRBM).
+            n_clusters: Number of output clusters.
+            n_hidden: Hidden layer size in the clustering head.
+            noise_std: Std of Gaussian noise used for IIC perturbations.
+        """
+        super(IICClusteringHead, self).__init__()
+
+        self.noise_std = noise_std
+
+        # Two fully connected layers -- same pattern as SIT-FUSE's
+        # clustering head architecture from the paper
+        self.fc = nn.Sequential(
+            nn.Linear(n_input, n_hidden),
+            nn.ReLU(),
+            nn.Linear(n_hidden, n_clusters),
+            nn.Softmax(dim=1),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Returns soft cluster assignments for input embeddings.
+
+        Args:
+            x: Encoder output, shape (batch, n_input).
+
+        Returns:
+            Cluster probabilities, shape (batch, n_clusters).
+        """
+        return self.fc(x)
+
+    def perturb(self, x: torch.Tensor) -> torch.Tensor:
+        """Adds Gaussian noise to encoder output for IIC perturbation.
+
+        Mirrors SIT-FUSE's perturbation strategy: Gaussian noise added
+        to RBM-based encoder outputs before the clustering head.
+
+        Args:
+            x: Encoder output, shape (batch, n_input).
+
+        Returns:
+            Perturbed encoder output, same shape.
+        """
+        return x + torch.randn_like(x) * self.noise_std
+
+    @staticmethod
+    def iic_loss(p: torch.Tensor, p_perturbed: torch.Tensor, eps: float = 1e-6) -> torch.Tensor:
+        """Computes the IIC loss (negative mutual information).
+
+        Maximizes mutual information between cluster assignments of a
+        sample and its perturbed version. Per Ji et al. (2019):
+            I(z; z') = sum_{c,c'} P(c,c') * log[ P(c,c') / (P(c)*P(c')) ]
+
+        Args:
+            p: Cluster probabilities, shape (batch, n_clusters).
+            p_perturbed: Cluster probs for perturbed version, same shape.
+            eps: Small value for numerical stability.
+
+        Returns:
+            Scalar IIC loss (negative mutual information, to minimize).
+        """
+        # Joint distribution P(c, c') -- outer product averaged over batch
+        # Shape: (n_clusters, n_clusters)
+        p_joint = torch.einsum("bi,bj->ij", p, p_perturbed) / p.shape[0]
+        p_joint = (p_joint + p_joint.t()) / 2  # symmetrize
+        p_joint = torch.clamp(p_joint, min=eps)
+
+        # Marginal distributions
+        p_i = p_joint.sum(dim=1, keepdim=True)  # (n_clusters, 1)
+        p_j = p_joint.sum(dim=0, keepdim=True)  # (1, n_clusters)
+
+        # Mutual information (negative, since we minimize loss)
+        mi = (p_joint * (torch.log(p_joint) -
+              torch.log(p_i) - torch.log(p_j))).sum()
+
+        return -mi
+
+
+class RTDBN(Model):
+    """Recurrent Temporal Deep Belief Network.
+
+    Wraps one or more RTRBMs into a deep stack, mirroring learnergy's
+    DBN (dbn.py) structure but adapted for temporal sequences.
+
+    Per Nick's direction: start with one layer. Adding more layers
+    later is just changing n_hidden from (64,) to (64, 32) etc.
+    """
+
+    def __init__(
+        self,
+        model: Tuple[str, ...] = ("variance_gaussian",),
+        n_visible: int = 78,
+        n_hidden: Tuple[int, ...] = (64,),
+        steps: Tuple[int, ...] = (1,),
+        learning_rate: Tuple[float, ...] = (0.001,),
+        momentum: Tuple[float, ...] = (0.0,),
+        decay: Tuple[float, ...] = (0.0,),
+        temperature: Tuple[float, ...] = (1.0,),
+        use_gpu: bool = False,
+        n_clusters: int = 10,
+        cluster_hidden: int = 256,
+        noise_std: float = 0.1,
+    ) -> None:
+        """Initialization method.
+
+        Mirrors DBN.__init__ (dbn.py) exactly in parameter structure,
+        adapted for RTRBM layer types and the addition of the IIC
+        clustering head.
+
+        Args:
+            model: Tuple of RTRBM type strings, one per layer.
+                   Currently supports: "variance_gaussian".
+            n_visible: Number of visible units (input features).
+            n_hidden: Tuple of hidden unit counts, one per layer.
+            steps: CD-k steps per layer.
+            learning_rate: Learning rate per layer.
+            momentum: Momentum per layer.
+            decay: Weight decay per layer.
+            temperature: Temperature per layer.
+            use_gpu: Whether to use GPU.
+            n_clusters: Number of output clusters for IIC head.
+            cluster_hidden: Hidden size of IIC clustering head.
+            noise_std: Std of Gaussian perturbation noise for IIC.
+        """
+        logger.info("Overriding class: Model -> RTDBN.")
+
+        super(RTDBN, self).__init__(use_gpu=use_gpu)
+
+        self.n_visible = n_visible
+        self.n_hidden = n_hidden
+        self.n_layers = len(n_hidden)
+
+        self.steps = steps
+        self.lr = learning_rate
+        self.momentum = momentum
+        self.decay = decay
+        self.T = temperature
+
+        if not isinstance(model, tuple):
+            model = (model,)
+
+        # Build RTRBM layers -- mirrors DBN's nn.ModuleList pattern
+        self.models = nn.ModuleList([])
+        for i in range(self.n_layers):
+            n_input = self.n_visible if i == 0 else self.n_hidden[i - 1]
+
+            if model[i] not in RT_MODELS:
+                raise e.ValueError(
+                    f"Model '{model[i]}' not supported. "
+                    f"Choose from: {list(RT_MODELS.keys())}"
+                )
+
+            m = RT_MODELS[model[i]](
+                n_visible=n_input,
+                n_hidden=self.n_hidden[i],
+                steps=self.steps[i],
+                learning_rate=self.lr[i],
+                momentum=self.momentum[i],
+                decay=self.decay[i],
+                temperature=self.T[i],
+                use_gpu=use_gpu,
+            )
+            self.models.append(m)
+
+        # IIC clustering head -- takes the temporal embedding from the
+        # last RTRBM layer and produces cluster assignments
+        self.clustering_head = IICClusteringHead(
+            n_input=self.n_hidden[-1],
+            n_clusters=n_clusters,
+            n_hidden=cluster_hidden,
+            noise_std=noise_std,
+        )
+
+        if self.device == "cuda":
+            self.cuda()
+
+        logger.info("Class overrided.")
+        logger.debug("Number of layers: %d.", self.n_layers)
+
+    @property
+    def n_visible(self) -> int:
+        return self._n_visible
+
+    @n_visible.setter
+    def n_visible(self, n_visible: int) -> None:
+        if n_visible <= 0:
+            raise e.ValueError("`n_visible` should be > 0")
+        self._n_visible = n_visible
+
+    @property
+    def n_hidden(self) -> Tuple[int, ...]:
+        return self._n_hidden
+
+    @n_hidden.setter
+    def n_hidden(self, n_hidden: Tuple[int, ...]) -> None:
+        self._n_hidden = n_hidden
+
+    @property
+    def n_layers(self) -> int:
+        return self._n_layers
+
+    @n_layers.setter
+    def n_layers(self, n_layers: int) -> None:
+        if n_layers <= 0:
+            raise e.ValueError("`n_layers` should be > 0")
+        self._n_layers = n_layers
+
+    def encode(self, x: torch.Tensor) -> torch.Tensor:
+        """Encodes a sequence through all RTRBM layers and returns a
+        temporal embedding via mean pooling over the time axis.
+
+        This is the key method connecting RTDBN to the IIC clustering
+        head: the (batch, seq_len, n_hidden) output of forward() is
+        collapsed to (batch, n_hidden) by averaging over timesteps,
+        giving one embedding per sequence that can be clustered.
+
+        Args:
+            x: Input sequences, shape (batch, seq_len, n_visible).
+
+        Returns:
+            Temporal embeddings, shape (batch, n_hidden[-1]).
+        """
+        # Pass through each RTRBM layer sequentially --
+        # mirrors DBN.forward()'s layer-by-layer pattern (dbn.py line 404)
+        # but adapted for temporal (batch, seq_len, n_features) shape
+        h = x
+        for model in self.models:
+            h = model.forward(h)  # (batch, seq_len, n_hidden_i)
+
+        # Mean pool over time axis: (batch, seq_len, n_hidden) -> (batch, n_hidden)
+        # Standard approach for collapsing sequence embeddings to fixed-size vectors
+        embedding = h.mean(dim=1)
+
+        return embedding
+
+    def forward(self, x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Full forward pass: encode sequences and produce cluster assignments.
+
+        Args:
+            x: Input sequences, shape (batch, seq_len, n_visible).
+
+        Returns:
+            (embeddings, cluster_probs):
+            - embeddings: shape (batch, n_hidden[-1]) -- temporal embeddings
+            - cluster_probs: shape (batch, n_clusters) -- soft cluster assignments
+        """
+        embeddings = self.encode(x)
+        cluster_probs = self.clustering_head(embeddings)
+        return embeddings, cluster_probs
+
+    def fit(
+        self,
+        dataset: torch.utils.data.Dataset,
+        batch_size: int = 32,
+        epochs: Tuple[int, ...] = (30,),
+        warmup_epochs: Tuple[int, ...] = (15,),
+    ) -> List[torch.Tensor]:
+        """Trains each RTRBM layer sequentially, mirroring DBN.fit().
+
+        Layer 0 trains on raw sequences. Each subsequent layer trains
+        on the temporal output of the previous layer -- same greedy
+        layer-wise pre-training as DBN (dbn.py lines 305-341), adapted
+        for sequence data.
+
+        Args:
+            dataset: SFTemporalDataset where each sample is (seq_len, n_visible).
+            batch_size: Batch size.
+            epochs: Training epochs per layer.
+            warmup_epochs: Sigma warmup epochs per layer (only used by
+                RTVarianceGaussianRBM -- number of epochs to freeze sigma).
+
+        Returns:
+            List of final MSE per layer.
+        """
+        if len(epochs) != self.n_layers:
+            raise e.SizeError(
+                f"`epochs` should have size equal to {self.n_layers}"
+            )
+
+        mse_per_layer = []
+
+        for i, model in enumerate(self.models):
+            logger.info("Fitting RTDBN layer %d/%d ...", i + 1, self.n_layers)
+
+            if i == 0:
+                # First layer trains on raw sequences
+                warmup = warmup_epochs[i] if i < len(warmup_epochs) else 0
+                full = epochs[i] - warmup
+
+                if warmup > 0:
+                    model.sigma.requires_grad_(False)
+                    model.fit(dataset, batch_size=batch_size, epochs=warmup)
+
+                model.sigma.requires_grad_(True)
+                model.fit(dataset, batch_size=batch_size, epochs=full)
+
+                mse_per_layer.append(model.history["mse"][-1])
+
+            else:
+                # Subsequent layers train on hidden output of previous layers.
+                # We need to transform the dataset by passing it through
+                # all previous layers first -- same principle as DBN.fit()
+                # lines 325-326 which pass samples through previous models.
+                # TODO: implement multi-layer training when n_layers > 1.
+                # For now, Nick said start with one layer -- this path won't
+                # be hit with the default single-layer config.
+                raise NotImplementedError(
+                    "Multi-layer RTDBN training not yet implemented. "
+                    "Per Nick's direction, start with one layer "
+                    "(n_hidden=(64,)) -- this error should not appear "
+                    "in the single-layer configuration."
+                )
+
+        return mse_per_layer
+
+    def fit_clustering_head(
+        self,
+        dataset: torch.utils.data.Dataset,
+        batch_size: int = 32,
+        epochs: int = 20,
+        learning_rate: float = 0.001,
+    ) -> List[float]:
+        """Trains the IIC clustering head on top of the frozen RTRBM encoder.
+
+        Mirrors SIT-FUSE's pattern: encoder pre-trained first, then frozen,
+        then clustering head trained with IIC loss. Perturbations are Gaussian
+        noise added to encoder outputs, per the SIT-FUSE paper.
+
+        KEY FIX vs. original implementation:
+        - Embeddings are computed FRESH per batch inside the training loop,
+          not pre-cached with torch.no_grad(). Pre-caching caused the IIC
+          loss to stay at zero because all batches saw identical deterministic
+          embeddings -- the noise was the only source of variation, making
+          the joint distribution P(c,c') degenerate.
+        - Noise std is scaled RELATIVE to the embedding magnitude (10% of
+          per-batch std) rather than a fixed absolute value. The encoder
+          outputs are small in magnitude; fixed noise_std=0.1 was larger
+          than the entire embedding range, destroying the MI signal.
+
+        Args:
+            dataset: SFTemporalDataset (same as used for RTRBM training).
+            batch_size: Batch size.
+            epochs: Number of IIC training epochs.
+            learning_rate: Learning rate for clustering head optimizer.
+
+        Returns:
+            List of IIC loss values per epoch.
+        """
+        # Freeze the RTRBM encoder -- only train the clustering head
+        for model in self.models:
+            for param in model.parameters():
+                param.requires_grad_(False)
+
+        optimizer = torch.optim.Adam(
+            self.clustering_head.parameters(), lr=learning_rate
+        )
+
+        batches = DataLoader(
+            dataset, batch_size=batch_size, shuffle=True, num_workers=0
+        )
+
+        loss_history = []
+
+        for epoch in range(epochs):
+            epoch_loss = 0.0
+            n_batches = 0
+
+            for samples, _ in tqdm(batches, desc=f"IIC epoch {epoch+1}/{epochs}"):
+                if self.device == "cuda":
+                    samples = samples.cuda()
+
+                # Compute embeddings FRESH per batch -- NOT cached.
+                # Encoder is frozen so no grad needed through it,
+                # but embeddings must be computed here (not pre-cached)
+                # so each batch draws from the actual data distribution.
+                with torch.no_grad():
+                    embeddings = self.encode(samples)
+
+                # Scale noise relative to embedding magnitude --
+                # fixed noise_std can be too large or too small depending
+                # on the encoder's output scale. Using 10% of per-batch
+                # std keeps perturbations meaningful without destroying signal.
+                emb_std = embeddings.std().item()
+                adaptive_noise = max(emb_std * 0.1, 1e-4)
+
+                # Perturb embeddings (adaptive Gaussian noise)
+                perturbed = embeddings + \
+                    torch.randn_like(embeddings) * adaptive_noise
+
+                # Forward pass through clustering head
+                # embeddings.detach() so gradients only flow through
+                # the clustering head, not back to the frozen encoder
+                p = self.clustering_head(embeddings.detach())
+                p_perturbed = self.clustering_head(perturbed.detach())
+
+                # IIC loss
+                loss = IICClusteringHead.iic_loss(p, p_perturbed)
+
+                optimizer.zero_grad()
+                loss.backward()
+                optimizer.step()
+
+                epoch_loss += loss.item()
+                n_batches += 1
+
+            avg_loss = epoch_loss / n_batches
+            loss_history.append(avg_loss)
+            self.dump(iic_loss=avg_loss)
+
+            logger.info("IIC Epoch %d/%d | Loss: %.4f",
+                        epoch + 1, epochs, avg_loss)
+
+        # Unfreeze encoder after clustering head training
+        for model in self.models:
+            for param in model.parameters():
+                param.requires_grad_(True)
+
+        return loss_history
+
+    def fit_clustering_kmeans(
+        self,
+        dataset: torch.utils.data.Dataset,
+        batch_size: int = 32,
+        n_init: int = 10,
+    ) -> torch.Tensor:
+        """Clusters temporal embeddings using k-means.
+
+        Practical alternative to IIC for initial end-to-end analysis.
+        IIC requires training the encoder jointly with the clustering head
+        to learn discriminative features -- training a clustering head on
+        frozen RTRBM embeddings alone leads to collapse when the embeddings
+        lack sufficient discriminability (common at early training stages).
+
+        K-means directly on the frozen RTRBM embeddings is a reliable
+        starting point for qualitative analysis, consistent with SIT-FUSE's
+        earlier clustering approach (BIRCH/k-means before transitioning to
+        IIC per the paper). This produces meaningful clusters from whatever
+        structure the RTRBM has learned, without requiring joint training.
+
+        Args:
+            dataset: SFTemporalDataset to cluster.
+            batch_size: Batch size for embedding extraction.
+            n_init: Number of k-means initializations (higher = more stable).
+
+        Returns:
+            Cluster assignment tensor, shape (n_samples,).
+        """
+        from sklearn.cluster import KMeans
+
+        # Extract all embeddings
+        embeddings, _ = self.get_cluster_assignments(dataset, batch_size)
+        emb_np = embeddings.numpy()
+
+        # Fit k-means
+        km = KMeans(
+            n_clusters=self.clustering_head.fc[-2].out_features,
+            n_init=n_init,
+            random_state=42,
+        )
+        assignments = km.fit_predict(emb_np)
+
+        return torch.from_numpy(assignments)
+
+    def get_cluster_assignments(
+        self, dataset: torch.utils.data.Dataset, batch_size: int = 32
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Returns cluster assignments and embeddings for a full dataset.
+
+        This is the main analysis output -- used to visualize what the
+        model has learned about the structure of the biomechanical data.
+
+        Args:
+            dataset: SFTemporalDataset to cluster.
+            batch_size: Batch size.
+
+        Returns:
+            (embeddings, cluster_assignments):
+            - embeddings: shape (n_samples, n_hidden[-1])
+            - cluster_assignments: shape (n_samples,) -- hard cluster labels
+        """
+        batches = DataLoader(
+            dataset, batch_size=batch_size, shuffle=False, num_workers=0
+        )
+
+        all_embeddings = []
+        all_assignments = []
+
+        with torch.no_grad():
+            for samples, _ in tqdm(batches):
+                if self.device == "cuda":
+                    samples = samples.cuda()
+
+                embeddings, cluster_probs = self.forward(samples)
+                assignments = torch.argmax(cluster_probs, dim=1)
+
+                all_embeddings.append(embeddings)
+                all_assignments.append(assignments)
+
+        return (
+            torch.cat(all_embeddings, dim=0),
+            torch.cat(all_assignments, dim=0),
+        )

--- a/learnergy/models/temporal/rtrbm.py
+++ b/learnergy/models/temporal/rtrbm.py
@@ -1,15 +1,3 @@
-"""Recurrent Temporal Restricted Boltzmann Machine (Bernoulli-Bernoulli).
-
-DEV NOTE: this file lives in the sit_fuse_rtrbm dev package for now so it
-can be built/tested against the real installed `learnergy` package without
-naming collisions. Once ready for the actual upstream contribution, this
-file gets copied into a fork of github.com/gugarosa/learnergy at
-learnergy/models/temporal/rtrbm.py -- see Technical Design Note.
-
-Reference:
-    I. Sutskever, G. Hinton, G. Taylor. The recurrent temporal restricted
-    Boltzmann machine. NeurIPS (2008).
-"""
 from typing import Tuple
 
 import torch
@@ -25,13 +13,6 @@ logger = logging.get_logger(__name__)
 
 
 class RTRBM(RBM):
-    """Single-layer Bernoulli-Bernoulli RTRBM. Extends RBM (learnergy's
-    bernoulli/rbm.py) with a hidden-to-hidden recurrent weight matrix W'
-    and a learnable initial hidden state, so the hidden bias at each
-    timestep is conditioned on the mean-field hidden probabilities of the
-    PREVIOUS timestep.
-    """
-
     def __init__(
         self,
         n_visible: int = 128,
@@ -43,12 +24,6 @@ class RTRBM(RBM):
         temperature: float = 1.0,
         use_gpu: bool = False,
     ) -> None:
-        """Initialization method.
-
-        Args mirror RBM's __init__ exactly (see learnergy's rbm.py) -- no
-        new hyperparameters at the base layer beyond what's needed for the
-        recurrent connection, added below.
-        """
 
         logger.info("Overriding class: RBM -> RTRBM.")
 
@@ -94,26 +69,6 @@ class RTRBM(RBM):
     def hidden_sampling(
         self, v: torch.Tensor, h_prev: torch.Tensor, scale: bool = False
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        """Performs the hidden layer sampling, i.e., P(h_t | v_t, h_{t-1}).
-
-        Overrides RBM.hidden_sampling (learnergy's rbm.py) to add the
-        recurrent term. NOTE the changed signature vs. the parent class --
-        this now REQUIRES h_prev (previous timestep's mean-field hidden
-        probs). Deliberate deviation from RBM's API -- see RTRBM Technical
-        Design Note re: forward-compatibility with DBN.forward().
-
-        Args:
-            v: Visible layer tensor for the CURRENT timestep, shape
-                (batch, n_visible).
-            h_prev: Mean-field hidden probabilities from the PREVIOUS
-                timestep, shape (batch, n_hidden). Use self.h0 (broadcast
-                to batch size) for the first timestep in a sequence.
-            scale: same role as in RBM.hidden_sampling -- whether to divide
-                by temperature T.
-
-        Returns:
-            Probabilities and states of the hidden layer sampling.
-        """
         recurrent_bias = F.linear(h_prev, self.W_prime, self.b)
         activations = F.linear(v, self.W.t()) + recurrent_bias
 
@@ -127,26 +82,6 @@ class RTRBM(RBM):
         return probs, states
 
     def energy(self, samples: torch.Tensor, h_prev: torch.Tensor) -> torch.Tensor:
-        """Calculates and frees the system's energy, ACCOUNTING FOR the
-        recurrent bias term.
-
-        Overrides RBM.energy (learnergy's rbm.py). NECESSARY override, not
-        optional: the parent class's energy() uses only the plain bias
-        `self.b`, which would silently ignore the recurrent contribution
-        `W_prime @ h_prev` that hidden_sampling actually uses. If left
-        un-overridden, the energy used to compute the CD-k training cost
-        would not match the distribution actually being sampled from --
-        meaning W_prime's gradient signal would be wrong/missing during
-        training, even though hidden_sampling itself works correctly.
-
-        Args:
-            samples: Samples to be energy-freed, shape (batch, n_visible).
-            h_prev: Same previous-timestep hidden probabilities used in
-                hidden_sampling for this timestep, shape (batch, n_hidden).
-
-        Returns:
-            The system's energy based on input samples, shape (batch,).
-        """
         recurrent_bias = F.linear(h_prev, self.W_prime, self.b)
         activations = F.linear(samples, self.W.t()) + recurrent_bias
 
@@ -164,27 +99,10 @@ class RTRBM(RBM):
         """Performs the whole Gibbs sampling procedure FOR ONE TIMESTEP.
 
         Overrides RBM.gibbs_sampling (learnergy's rbm.py) to thread h_prev
-        through every hidden_sampling call. IMPORTANT: h_prev stays FIXED
+        through every hidden_sampling call. h_prev stays FIXED
         across all CD-k steps within this call -- it is the recurrent
         context for THIS timestep only, not something that changes during
-        the k Gibbs-sampling bounces. (The recurrence across TIMESTEPS
-        happens one level up, in the training loop that calls this
-        function once per timestep with an updated h_prev each time --
-        not implemented yet, see fit() below.)
-
-        This matches "independent CD-k per timestep" as decided with Nick
-        (2026-06-29): each timestep runs its own self-contained CD-k, with
-        the only cross-timestep influence being the fixed h_prev bias.
-
-        Args:
-            v: Visible layer tensor for the CURRENT timestep.
-            h_prev: Previous timestep's hidden probabilities (fixed for
-                the duration of this call).
-
-        Returns:
-            Same 5-tuple as RBM.gibbs_sampling: positive hidden
-            probs/states, negative hidden probs/states, negative visible
-            states.
+        the k Gibbs-sampling bounces.
         """
         pos_hidden_probs, pos_hidden_states = self.hidden_sampling(v, h_prev)
         neg_hidden_states = pos_hidden_states
@@ -204,43 +122,6 @@ class RTRBM(RBM):
         )
 
     def cd_step(self, v: torch.Tensor, h_prev: torch.Tensor) -> torch.Tensor:
-        """Performs ONE Contrastive Divergence training step, for ONE
-        timestep's worth of data. This is the basic building block that
-        fit() will eventually loop over -- one frame, one CD-k update.
-
-        Mirrors the inner-loop body of RBM.fit() (learnergy's rbm.py)
-        almost exactly -- positive phase -> Gibbs sampling -> cost ->
-        backward -> optimizer step -- just using THIS class's
-        gibbs_sampling/energy (which both take h_prev) instead of the
-        parent's.
-
-        NOTE on pseudo_likelihood: RBM.fit() also tracks log-PL via
-        self.pseudo_likelihood(), but that inherited method internally
-        calls self.energy(samples) with the PARENT's one-argument
-        signature -- incompatible with RTRBM's energy(samples, h_prev).
-        This is consistent with the Technical Design Note's existing
-        deferral of pseudo_likelihood for this model. Not computed here;
-        only MSE is tracked for now.
-
-        NOTE: this does NOT zero/step the optimizer's gradient
-        accumulation across multiple calls in a sequence -- that
-        coordination (zero_grad once per subseries, not once per
-        timestep, so gradients accumulate correctly across the whole
-        chain for BPTT) belongs in fit()'s outer loop, not here. Calling
-        this method standalone (as the smoke test below does) performs
-        zero_grad/step every call, which is correct ONLY for testing a
-        single isolated timestep in isolation -- not for real subseries
-        training.
-
-        Args:
-            v: Visible layer tensor for this timestep, shape
-                (batch, n_visible).
-            h_prev: Previous timestep's hidden probabilities, shape
-                (batch, n_hidden).
-
-        Returns:
-            mse -- reconstruction error for this one step.
-        """
         _, _, _, _, visible_states = self.gibbs_sampling(v, h_prev)
         visible_states = visible_states.detach()
 
@@ -265,27 +146,10 @@ class RTRBM(RBM):
         computation, but accumulating cost ACROSS THE WHOLE SUBSERIES
         before a SINGLE backward() + optimizer step.
 
-        This is the actual BPTT mechanism: h_prev is carried forward
+        BPTT: h_prev is carried forward
         WITHOUT detaching between timesteps, so gradients from later
         timesteps' cost can flow backward through the h_prev chain into
-        earlier timesteps' contribution to W_prime and h0. This matches
-        Nick's decision (2026-06-29): train on subseries (not full long
-        sequences), independent CD-k per timestep for the W/a/b
-        contribution, per the original paper.
-
-        Contrast with cd_step(): that method does zero_grad/backward/step
-        on EVERY call, which is correct for testing one timestep in total
-        isolation, but WRONG for chained training -- it would correct the
-        model after every single frame and never let gradients flow
-        across the chain at all. This method is the one to actually use
-        for subseries training.
-
-        Args:
-            sequence: ONE subseries, shape (batch, seq_len, n_visible).
-
-        Returns:
-            mse -- summed reconstruction error across all timesteps in
-            the subseries (a single scalar, already detached).
+        earlier timesteps' contribution to W_prime and h0.
         """
         batch_size, seq_len, n_visible = sequence.shape
 
@@ -332,29 +196,6 @@ class RTRBM(RBM):
         batch_size: int = 128,
         epochs: int = 10,
     ) -> torch.Tensor:
-        """Fits a new RTRBM model on a dataset of subseries sequences.
-
-        Outer training loop wrapping fit_subseries() -- mirrors RBM.fit()
-        (learnergy's rbm.py) in structure: DataLoader -> epoch loop ->
-        batch loop -> per-epoch self.dump() for history tracking.
-
-        Key differences from RBM.fit():
-        - Each "sample" is a SEQUENCE of shape (seq_len, n_visible), not
-          a flat (n_visible,) vector. DataLoader returns batches of shape
-          (batch, seq_len, n_visible) -- no reshaping needed.
-        - Inner training step is fit_subseries(), not a single CD-k call.
-        - Returns only mse (not (mse, pl)) since pseudo_likelihood is
-          deferred for this model (see cd_step() docstring).
-
-        Args:
-            dataset: A SFTemporalDataset (or compatible Dataset) where
-                each sample is a sequence of shape (seq_len, n_visible).
-            batch_size: Number of sequences per batch.
-            epochs: Number of full passes through the dataset.
-
-        Returns:
-            mse from the final epoch.
-        """
         import time
         from torch.utils.data import DataLoader
         from tqdm import tqdm

--- a/learnergy/models/temporal/rtrbm.py
+++ b/learnergy/models/temporal/rtrbm.py
@@ -38,9 +38,6 @@ class RTRBM(RBM):
         # Learnable initial hidden state, used at t=0 (no h_{-1} exists).
         self.h0 = nn.Parameter(torch.zeros(n_hidden))
 
-        # Mirrors VarianceGaussianRBM's pattern (gaussian_rbm.py) of
-        # registering new nn.Parameters with the optimizer AFTER
-        # super().__init__() has already built it.
         self.optimizer.add_param_group({"params": [self.W_prime, self.h0]})
 
         if self.device == "cuda":
@@ -97,12 +94,6 @@ class RTRBM(RBM):
         self, v: torch.Tensor, h_prev: torch.Tensor
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
         """Performs the whole Gibbs sampling procedure FOR ONE TIMESTEP.
-
-        Overrides RBM.gibbs_sampling (learnergy's rbm.py) to thread h_prev
-        through every hidden_sampling call. h_prev stays FIXED
-        across all CD-k steps within this call -- it is the recurrent
-        context for THIS timestep only, not something that changes during
-        the k Gibbs-sampling bounces.
         """
         pos_hidden_probs, pos_hidden_states = self.hidden_sampling(v, h_prev)
         neg_hidden_states = pos_hidden_states
@@ -141,15 +132,9 @@ class RTRBM(RBM):
         return mse
 
     def fit_subseries(self, sequence: torch.Tensor) -> torch.Tensor:
-        """Trains on ONE subseries (a short chunk of consecutive
-        timesteps), using independent CD-k per timestep for the cost
+        """Trains on ONE subseries, using independent CD-k per timestep for the cost
         computation, but accumulating cost ACROSS THE WHOLE SUBSERIES
         before a SINGLE backward() + optimizer step.
-
-        BPTT: h_prev is carried forward
-        WITHOUT detaching between timesteps, so gradients from later
-        timesteps' cost can flow backward through the h_prev chain into
-        earlier timesteps' contribution to W_prime and h0.
         """
         batch_size, seq_len, n_visible = sequence.shape
 
@@ -176,13 +161,6 @@ class RTRBM(RBM):
             ).detach()
             total_mse = total_mse + batch_mse
 
-            # CRITICAL: do NOT detach here. h_prev for the NEXT timestep
-            # must stay attached to the computation graph, or gradients
-            # from this timestep onward could never flow back to W_prime/
-            # h0's contribution at EARLIER timesteps -- which would
-            # silently turn this into "independent CD-k with no real BPTT
-            # at all," defeating the entire point of this method vs.
-            # cd_step().
             h_prev, _ = self.hidden_sampling(v_t, h_prev)
 
         total_cost.backward()


### PR DESCRIPTION
Adds three more temporal model classes to the Bernoulli RTRBM.

- RTGaussianRBM: Gaussian visible units for continuous-valued data
- RTVarianceGaussianRBM: learned per-feature variance w/ two-phase sigma warmup training strategy
- RTDBN: stacked RTRBM architecture with IIC clustering head and k-means clustering support